### PR TITLE
npmignore unneeded files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+bench
+test
+.jshintignore
+.jshintrc
+.travis.yml
+History.md


### PR DESCRIPTION
No point in wasting bandwidth and space. This would make the module 1.7MB smaller.
