### PR TITLE
Allow keepSpecialComments to be set as a string

### DIFF
--- a/lib/text/comments.js
+++ b/lib/text/comments.js
@@ -45,10 +45,12 @@ module.exports = function Comments(keepSpecialComments, keepBreaks, lineBreak) {
           case '*':
             return comments.restore(placeholder) + breakSuffix;
           case 1:
+          case '1':
             return restored == 1 ?
               comments.restore(placeholder) + breakSuffix :
               '';
           case 0:
+          case '0':
             return '';
         }
       });

--- a/test/unit-test.js
+++ b/test/unit-test.js
@@ -273,6 +273,12 @@ vows.describe('clean-units').addBatch({
       "@charset 'utf-8';a{}"
     ]
   }, { keepSpecialComments: 0 }),
+  'important comments - keepSpecialComments when a string': cssContext({
+    'strip all': [
+      '/*! important comment */a{color:red}/* some comment *//*! important comment */',
+      'a{color:red}'
+    ]
+  }, { keepSpecialComments: '0' }),
   'expressions': cssContext({
     'empty': 'a{color:expression()}',
     'method call': 'a{color:expression(this.parentNode.currentStyle.color)}',


### PR DESCRIPTION
On grunt-contrib-cssmin, some users are setting `keepSpecialComments` as a string instead of a number. This causes `undefined` to be prepended to their file. See gruntjs/grunt-contrib-cssmin#40

This would make setting that option with `'1'` or `'0'` work the same as a number directly. Hopefully this will prevent the error from their common mistake.

Thanks!
