### PR TITLE
ignore arbitrary @import in comment

### DIFF
--- a/lib/imports/inliner.js
+++ b/lib/imports/inliner.js
@@ -9,6 +9,7 @@ module.exports = function Inliner() {
     var nextStart = 0;
     var nextEnd = 0;
     var cursor = 0;
+    var isComment = commentScanner(data);
 
     options.relativeTo = options.relativeTo || options.root;
     options._baseRelativeTo = options._baseRelativeTo || options.relativeTo;
@@ -18,6 +19,11 @@ module.exports = function Inliner() {
       nextStart = data.indexOf('@import', cursor);
       if (nextStart == -1)
         break;
+
+      if (isComment(nextStart)) {
+        cursor = nextStart + 1;
+        continue;
+      }
 
       nextEnd = data.indexOf(';', nextStart);
       if (nextEnd == -1)
@@ -31,6 +37,52 @@ module.exports = function Inliner() {
     return tempData.length > 0 ?
       tempData.join('') + data.substring(cursor, data.length) :
       data;
+  };
+
+  var commentScanner = function(data) {
+    var commentRegex = /(\/\*(?!\*\/)[\s\S]*?\*\/)/;
+    var lastEndIndex = 0;
+    var noComments = false;
+
+    // test whether an index is located within a comment
+    var scanner = function(idx) {
+      var comment;
+      var localStartIndex = 0;
+      var localEndIndex = 0;
+      var globalStartIndex = 0;
+      var globalEndIndex = 0;
+
+      // return if we know there are no more comments
+      if (noComments)
+        return false;
+
+      comment = data.match(commentRegex);
+
+      if (!comment) {
+        noComments = true;
+        return false;
+      }
+
+      // get the indexes relative to the current data chunk
+      localStartIndex = comment.index;
+      localEndIndex = localStartIndex + comment[0].length;
+
+      // calculate the indexes relative to the full original data
+      globalEndIndex = localEndIndex + lastEndIndex;
+      globalStartIndex = globalEndIndex - comment[0].length;
+
+      // chop off data up to and including current comment block
+      data = data.substring(localEndIndex);
+      lastEndIndex = globalEndIndex;
+
+      // re-run scan if comment ended before the idx
+      if (globalEndIndex < idx)
+        return scanner(idx);
+
+      return globalEndIndex > idx && idx > globalStartIndex;
+    };
+
+    return scanner;
   };
 
   var inlinedFile = function(data, nextStart, nextEnd, options) {

--- a/test/unit-test.js
+++ b/test/unit-test.js
@@ -981,6 +981,18 @@ title']",
       '/* @import url(test/data/partials/five.css); */a { color: red; }',
       'a{color:red}'
     ],
+    'used arbitrarily in comment': [
+      '/* @import foo */a { color: red; }',
+      'a{color:red}'
+    ],
+    'used arbitrarily in comment multiple times': [
+      '/* @import foo */a { color: red; }\n/* @import bar */p { color: red; }',
+      'a{color:red}p{color:red}'
+    ],
+    'used arbitrarily in comment including unrelated comment': [
+      '/* foo */a { color: red; }/* bar *//* @import */',
+      'a{color:red}'
+    ],
     'of a file with a comment': [
       '@import url(test/data/partials/comment.css);',
       ''


### PR DESCRIPTION
@import used in comments without "url (..." causes "Broken @import declaration" exceptions to be thrown.

It's probably not the most efficient solution as it saves all comment positions in memory, but it solved the problem.
