### PR TITLE
Enable `eqeq`

### DIFF
--- a/bin/cleancss
+++ b/bin/cleancss
@@ -10,7 +10,7 @@ var commands = require('commander');
 var packageConfig = fs.readFileSync(path.join(path.dirname(fs.realpathSync(process.argv[1])), '../package.json'));
 var buildVersion = JSON.parse(packageConfig).version;
 
-var isWindows = process.platform == 'win32';
+var isWindows = process.platform === 'win32';
 
 // Specify commander options to parse command line params correctly
 commands

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -23,7 +23,7 @@ var UrlsProcessor = require('./text/urls');
 var SelectorsOptimizer = require('./selectors/optimizer');
 
 module.exports = function(options) {
-  var lineBreak = process.platform == 'win32' ? '\r\n' : '\n';
+  var lineBreak = process.platform === 'win32' ? '\r\n' : '\n';
   var stats = {};
 
   options = options || {};
@@ -41,7 +41,7 @@ module.exports = function(options) {
     }
 
     var replace = function() {
-      if (typeof arguments[0] == 'function')
+      if (typeof arguments[0] === 'function')
         arguments[0]();
       else
         data = data.replace.apply(data, arguments);
@@ -51,7 +51,7 @@ module.exports = function(options) {
     if (options.benchmark) {
       var originalReplace = replace;
       replace = function(pattern, replacement) {
-        var name = typeof pattern == 'function' ?
+        var name = typeof pattern === 'function' ?
           /function (\w+)\(/.exec(pattern.toString())[1] :
           pattern;
 
@@ -195,12 +195,12 @@ module.exports = function(options) {
 
     // replace font weight with numerical value
     replace(/(font\-weight|font):(normal|bold)([ ;\}!])(\w*)/g, function(match, property, weight, suffix, next) {
-      if (suffix == ' ' && next.length > 0 && !/[.\d]/.test(next))
+      if (suffix === ' ' && next.length > 0 && !/[.\d]/.test(next))
         return match;
 
-      if (weight == 'normal')
+      if (weight === 'normal')
         return property + ':400' + suffix + next;
-      else if (weight == 'bold')
+      else if (weight === 'bold')
         return property + ':700' + suffix + next;
       else
         return match;
@@ -218,9 +218,9 @@ module.exports = function(options) {
     // restore 0% in hsl/hsla
     replace(/(hsl|hsla)\(([^\)]+)\)/g, function(match, colorFunction, colorDef) {
       var tokens = colorDef.split(',');
-      if (tokens[1] == '0')
+      if (tokens[1] === '0')
         tokens[1] = '0%';
-      if (tokens[2] == '0')
+      if (tokens[2] === '0')
         tokens[2] = '0%';
       return colorFunction + '(' + tokens.join(',') + ')';
     });

--- a/lib/colors/hsl-to-hex.js
+++ b/lib/colors/hsl-to-hex.js
@@ -41,9 +41,9 @@ module.exports = function HSLToHex(data) {
         var blueAsHex = asRgb[2].toString(16);
 
         return '#' +
-          ((redAsHex.length == 1 ? '0' : '') + redAsHex) +
-          ((greenAsHex.length == 1 ? '0' : '') + greenAsHex) +
-          ((blueAsHex.length == 1 ? '0' : '') + blueAsHex);
+          ((redAsHex.length === 1 ? '0' : '') + redAsHex) +
+          ((greenAsHex.length === 1 ? '0' : '') + greenAsHex) +
+          ((blueAsHex.length === 1 ? '0' : '') + blueAsHex);
       });
     }
   };

--- a/lib/colors/long-to-short-hex.js
+++ b/lib/colors/long-to-short-hex.js
@@ -2,7 +2,7 @@ module.exports = function LongToShortHex(data) {
   return {
     process: function() {
       return data.replace(/([,: \(])#([0-9a-f]{6})/gi, function(match, prefix, color) {
-        if (color[0] == color[1] && color[2] == color[3] && color[4] == color[5])
+        if (color[0] === color[1] && color[2] === color[3] && color[4] === color[5])
           return prefix + '#' + color[0] + color[2] + color[4];
         else
           return prefix + '#' + color;

--- a/lib/colors/rgb-to-hex.js
+++ b/lib/colors/rgb-to-hex.js
@@ -7,9 +7,9 @@ module.exports = function RGBToHex(data) {
         var blueAsHex = parseInt(blue, 10).toString(16);
 
         return '#' +
-          ((redAsHex.length == 1 ? '0' : '') + redAsHex) +
-          ((greenAsHex.length == 1 ? '0' : '') + greenAsHex) +
-          ((blueAsHex.length == 1 ? '0' : '') + blueAsHex);
+          ((redAsHex.length === 1 ? '0' : '') + redAsHex) +
+          ((greenAsHex.length === 1 ? '0' : '') + greenAsHex) +
+          ((blueAsHex.length === 1 ? '0' : '') + blueAsHex);
       });
     }
   };

--- a/lib/images/url-rewriter.js
+++ b/lib/images/url-rewriter.js
@@ -9,11 +9,11 @@ module.exports = {
 
     for (; nextEnd < data.length; ) {
       nextStart = data.indexOf('url(', nextEnd);
-      if (nextStart == -1)
+      if (nextStart === -1)
         break;
 
       nextEnd = data.indexOf(')', nextStart + 4);
-      if (nextEnd == -1)
+      if (nextEnd === -1)
         break;
 
       tempData.push(data.substring(cursor, nextStart));
@@ -28,8 +28,8 @@ module.exports = {
   },
 
   _rebased: function(url, options) {
-    var specialUrl = url[0] == '/' ||
-      url.substring(url.length - 4) == '.css' ||
+    var specialUrl = url[0] === '/' ||
+      url.substring(url.length - 4) === '.css' ||
       url.indexOf('data:') === 0 ||
       /^https?:\/\//.exec(url) !== null ||
       /__\w+__/.exec(url) !== null;
@@ -46,7 +46,7 @@ module.exports = {
       rebased = path.relative(options.toBase, path.join(options.fromBase, url));
     }
 
-    return process.platform == 'win32' ?
+    return process.platform === 'win32' ?
       rebased.replace(/\\/g, '/') :
       rebased;
   }

--- a/lib/imports/inliner.js
+++ b/lib/imports/inliner.js
@@ -17,7 +17,7 @@ module.exports = function Inliner() {
 
     for (; nextEnd < data.length; ) {
       nextStart = data.indexOf('@import', cursor);
-      if (nextStart == -1)
+      if (nextStart === -1)
         break;
 
       if (isComment(nextStart)) {
@@ -26,7 +26,7 @@ module.exports = function Inliner() {
       }
 
       nextEnd = data.indexOf(';', nextStart);
-      if (nextEnd == -1)
+      if (nextEnd === -1)
         break;
 
       tempData.push(data.substring(cursor, nextStart));
@@ -102,7 +102,7 @@ module.exports = function Inliner() {
     if (/^(http|https):\/\//.test(importedFile) || /^\/\//.test(importedFile))
       return '@import url(' + importedFile + ')' + (mediaQuery.length > 0 ? ' ' + mediaQuery : '') + ';';
 
-    var relativeTo = importedFile[0] == '/' ?
+    var relativeTo = importedFile[0] === '/' ?
       options.root :
       options.relativeTo;
 
@@ -111,7 +111,7 @@ module.exports = function Inliner() {
     if (!fs.existsSync(fullPath) || !fs.statSync(fullPath).isFile())
       throw new Error('Broken @import declaration of "' + importedFile + '"');
 
-    if (options.visited.indexOf(fullPath) != -1)
+    if (options.visited.indexOf(fullPath) !== -1)
       return '';
 
     options.visited.push(fullPath);

--- a/lib/properties/optimizer.js
+++ b/lib/properties/optimizer.js
@@ -139,7 +139,7 @@ module.exports = function Optimizer() {
       var overrided = overrides[property];
       for (var i = 0, l = overrided.length; i < l; i++) {
         for (var j = 0; j < properties.length; j++) {
-          if (properties[j] != overrided[i] || (merged[j][2] && !isImportant))
+          if (properties[j] !== overrided[i] || (merged[j][2] && !isImportant))
             continue;
 
           merged.splice(j, 1);
@@ -161,8 +161,8 @@ module.exports = function Optimizer() {
       var token = tokens[i];
       var property = token[0];
       var isImportant = token[2];
-      var _property = (property == '-ms-filter' || property == 'filter') ?
-        (lastProperty == 'background' || lastProperty == 'background-image' ? lastProperty : property) :
+      var _property = (property === '-ms-filter' || property === 'filter') ?
+        (lastProperty === 'background' || lastProperty === 'background-image' ? lastProperty : property) :
         property;
       var toOverridePosition = 0;
 
@@ -171,10 +171,10 @@ module.exports = function Optimizer() {
       // e.g. a{display:inline-block;display:-moz-inline-box}
       // however if `mergeablePosition` yields true then the rule does not apply
       // (e.g merging two adjacent selectors: `a{display:block}a{display:block}`)
-      if (_property != lastProperty || mergeablePosition(i)) {
+      if (_property !== lastProperty || mergeablePosition(i)) {
         while (true) {
           toOverridePosition = properties.indexOf(_property, toOverridePosition);
-          if (toOverridePosition == -1)
+          if (toOverridePosition === -1)
             break;
 
           if (merged[toOverridePosition][2] && !isImportant)

--- a/lib/selectors/empty-removal.js
+++ b/lib/selectors/empty-removal.js
@@ -6,11 +6,11 @@ module.exports = function EmptyRemoval(data) {
 
     for (; nextEmpty < cssData.length; ) {
       nextEmpty = cssData.indexOf('{}', cursor);
-      if (nextEmpty == -1)
+      if (nextEmpty === -1)
         break;
 
       var startsAt = nextEmpty - 1;
-      while (cssData[startsAt] && cssData[startsAt] != '}' && cssData[startsAt] != '{')
+      while (cssData[startsAt] && cssData[startsAt] !== '}' && cssData[startsAt] !== '{')
         startsAt--;
 
       tempData.push(cssData.substring(cursor, startsAt + 1));

--- a/lib/selectors/optimizer.js
+++ b/lib/selectors/optimizer.js
@@ -16,7 +16,7 @@ module.exports = function Optimizer(data, options) {
     for (var i = 0, l = selectors.length; i < l; i++) {
       var sel = selectors[i];
 
-      if (plain.indexOf(sel) == -1)
+      if (plain.indexOf(sel) === -1)
         plain.push(sel);
     }
 
@@ -32,7 +32,7 @@ module.exports = function Optimizer(data, options) {
     var forRemoval = [];
 
     for (var i = 0, l = tokens.length; i < l; i++) {
-      if (typeof(tokens[i]) == 'string' || tokens[i].block)
+      if (typeof(tokens[i]) === 'string' || tokens[i].block)
         continue;
 
       var selector = tokens[i].selector;
@@ -61,14 +61,14 @@ module.exports = function Optimizer(data, options) {
     for (var i = 0, l = tokens.length; i < l; i++) {
       var token = tokens[i];
 
-      if (typeof(token) == 'string' || token.block)
+      if (typeof(token) === 'string' || token.block)
         continue;
 
-      if (token.selector == lastToken.selector) {
+      if (token.selector === lastToken.selector) {
         var joinAt = [lastToken.body.split(';').length];
         lastToken.body = propertyOptimizer.process(lastToken.body + ';' + token.body, joinAt);
         forRemoval.push(i);
-      } else if (token.body == lastToken.body && !isSpecial(token.selector) && !isSpecial(lastToken.selector)) {
+      } else if (token.body === lastToken.body && !isSpecial(token.selector) && !isSpecial(lastToken.selector)) {
         lastToken.selector = cleanUpSelector(lastToken.selector + ',' + token.selector);
         forRemoval.push(i);
       } else {
@@ -94,7 +94,7 @@ module.exports = function Optimizer(data, options) {
       token = tokens[i];
       selector = token.selector;
 
-      if (typeof(token) == 'string' || token.block)
+      if (typeof(token) === 'string' || token.block)
         continue;
 
       selectors = selector.split(',');
@@ -105,7 +105,7 @@ module.exports = function Optimizer(data, options) {
         var sel = selectors[j];
         var alreadyMatched = matched[sel];
         if (alreadyMatched) {
-          if (alreadyMatched.length == 1)
+          if (alreadyMatched.length === 1)
             matchedMoreThanOnce.push(sel);
           alreadyMatched.push(i);
         } else {
@@ -143,13 +143,13 @@ module.exports = function Optimizer(data, options) {
           .filter(removeEmpty)
           .join(';');
 
-        if (token.selector == selector) {
+        if (token.selector === selector) {
           token.body = reducedBody;
         } else {
           token._partials = token._partials || [];
           token._partials.push(reducedBody);
 
-          if (partiallyReduced.indexOf(tokenIndex) == -1)
+          if (partiallyReduced.indexOf(tokenIndex) === -1)
             partiallyReduced.push(tokenIndex);
         }
 
@@ -164,14 +164,14 @@ module.exports = function Optimizer(data, options) {
       token = tokens[partiallyReduced[i]];
       selectors = token.selector.split(',');
 
-      if (token._partials.length == selectors.length && token.body != token._partials[0]) {
+      if (token._partials.length === selectors.length && token.body !== token._partials[0]) {
         var newBody = token._partials[0];
         for (var k = 1, n = token._partials.length; k < n; k++) {
-          if (token._partials[k] != newBody)
+          if (token._partials[k] !== newBody)
             break;
         }
 
-        if (k == n)
+        if (k === n)
           token.body = newBody;
       }
 
@@ -200,7 +200,7 @@ module.exports = function Optimizer(data, options) {
   var rebuild = function(tokens) {
     return (Array.isArray(tokens) ? tokens : [tokens])
       .map(function(token) {
-        if (typeof token == 'string')
+        if (typeof token === 'string')
           return token;
 
         if (token.block)

--- a/lib/selectors/tokenizer.js
+++ b/lib/selectors/tokenizer.js
@@ -4,7 +4,7 @@ module.exports = function Tokenizer(data) {
     var mode = context.mode;
     var closest;
 
-    if (mode == 'body') {
+    if (mode === 'body') {
       closest = data.indexOf('}', cursor);
       return closest > -1 ?
         [closest, 'bodyEnd'] :
@@ -12,19 +12,19 @@ module.exports = function Tokenizer(data) {
     }
 
     var nextSpecial = data.indexOf('@', cursor);
-    var nextEscape = mode == 'top' ? data.indexOf('__ESCAPED_COMMENT_CLEAN_CSS', cursor) : -1;
+    var nextEscape = mode === 'top' ? data.indexOf('__ESCAPED_COMMENT_CLEAN_CSS', cursor) : -1;
     var nextBodyStart = data.indexOf('{', cursor);
     var nextBodyEnd = data.indexOf('}', cursor);
 
     closest = nextSpecial;
-    if (closest == -1 || (nextEscape > -1 && nextEscape < closest))
+    if (closest === -1 || (nextEscape > -1 && nextEscape < closest))
       closest = nextEscape;
-    if (closest == -1 || (nextBodyStart > -1 && nextBodyStart < closest))
+    if (closest === -1 || (nextBodyStart > -1 && nextBodyStart < closest))
       closest = nextBodyStart;
-    if (closest == -1 || (nextBodyEnd > -1 && nextBodyEnd < closest))
+    if (closest === -1 || (nextBodyEnd > -1 && nextBodyEnd < closest))
       closest = nextBodyEnd;
 
-    if (closest == -1)
+    if (closest === -1)
       return;
     if (nextEscape === closest)
       return [closest, 'escape'];
@@ -57,7 +57,7 @@ module.exports = function Tokenizer(data) {
       var nextEnd;
       var oldMode;
 
-      if (what == 'special') {
+      if (what === 'special') {
         var fragment = data.substring(nextSpecial, context.cursor + '@font-face'.length + 1);
         var isSingle = fragment.indexOf('@import') === 0 || fragment.indexOf('@charset') === 0;
         if (isSingle) {
@@ -78,13 +78,13 @@ module.exports = function Tokenizer(data) {
 
           tokenized.push({ block: block, body: specialBody });
         }
-      } else if (what == 'escape') {
+      } else if (what === 'escape') {
         nextEnd = data.indexOf('__', nextSpecial + 1);
         var escaped = data.substring(context.cursor, nextEnd + 2);
         tokenized.push(escaped);
 
         context.cursor = nextEnd + 2;
-      } else if (what == 'bodyStart') {
+      } else if (what === 'bodyStart') {
         var selector = data.substring(context.cursor, nextSpecial).trim();
 
         oldMode = context.mode;
@@ -94,14 +94,14 @@ module.exports = function Tokenizer(data) {
         context.mode = oldMode;
 
         tokenized.push({ selector: selector, body: body });
-      } else if (what == 'bodyEnd') {
+      } else if (what === 'bodyEnd') {
         // extra closing brace at the top level can be safely ignored
-        if (context.mode == 'top' && data[context.cursor] == '}') {
+        if (context.mode === 'top' && data[context.cursor] === '}') {
           context.cursor += 1;
           continue;
         }
 
-        if (context.mode != 'block')
+        if (context.mode !== 'block')
           tokenized = data.substring(context.cursor, nextSpecial);
 
         context.cursor = nextSpecial + 1;

--- a/lib/text/comments.js
+++ b/lib/text/comments.js
@@ -16,11 +16,11 @@ module.exports = function Comments(keepSpecialComments, keepBreaks, lineBreak) {
       for (; nextEnd < data.length; ) {
         nextStart = data.indexOf('/*', nextEnd);
         nextEnd = data.indexOf('*/', nextStart + 2);
-        if (nextStart == -1 || nextEnd == -1)
+        if (nextStart === -1 || nextEnd === -1)
           break;
 
         tempData.push(data.substring(cursor, nextStart));
-        if (data[nextStart + 2] == '!') {
+        if (data[nextStart + 2] === '!') {
           // in case of special comments, replace them with a placeholder
           var comment = data.substring(nextStart, nextEnd + 2);
           var placeholder = comments.store(comment);
@@ -46,7 +46,7 @@ module.exports = function Comments(keepSpecialComments, keepBreaks, lineBreak) {
             return comments.restore(placeholder) + breakSuffix;
           case 1:
           case '1':
-            return restored == 1 ?
+            return restored === 1 ?
               comments.restore(placeholder) + breakSuffix :
               '';
           case 0:

--- a/lib/text/expressions.js
+++ b/lib/text/expressions.js
@@ -12,15 +12,15 @@ module.exports = function Expressions() {
       var next = data[end++];
 
       if (quoted) {
-        quoted = next != '\'' && next != '"';
+        quoted = next !== '\'' && next !== '"';
       } else {
-        quoted = next == '\'' || next == '"';
+        quoted = next === '\'' || next === '"';
 
-        if (next == '(')
+        if (next === '(')
           level++;
-        if (next == ')')
+        if (next === ')')
           level--;
-        if (next == '}' && level == 1) {
+        if (next === '}' && level === 1) {
           end--;
           level--;
         }
@@ -45,7 +45,7 @@ module.exports = function Expressions() {
 
       for (; nextEnd < data.length; ) {
         nextStart = data.indexOf('expression(', nextEnd);
-        if (nextStart == -1)
+        if (nextStart === -1)
           break;
 
         nextEnd = findEnd(data, nextStart);

--- a/lib/text/free.js
+++ b/lib/text/free.js
@@ -8,7 +8,7 @@ module.exports = function Free() {
     while (true) {
       end = data.indexOf(matched, end);
 
-      if (end > -1 && data[end - 1] == '\\') {
+      if (end > -1 && data[end - 1] === '\\') {
         end += 1;
         continue;
       } else {
@@ -37,9 +37,9 @@ module.exports = function Free() {
         var nextStartSingle = data.indexOf(singleParenthesis, nextEnd + 1);
         var nextStartDouble = data.indexOf(doubleParenthesis, nextEnd + 1);
 
-        if (nextStartSingle == -1)
+        if (nextStartSingle === -1)
           nextStartSingle = dataLength;
-        if (nextStartDouble == -1)
+        if (nextStartDouble === -1)
           nextStartDouble = dataLength;
 
         if (nextStartSingle < nextStartDouble) {
@@ -50,11 +50,11 @@ module.exports = function Free() {
           matchedParenthesis = doubleParenthesis;
         }
 
-        if (nextStart == -1)
+        if (nextStart === -1)
           break;
 
         nextEnd = findNonEscapedEnd(data, matchedParenthesis, nextStart + 1);
-        if (nextEnd == -1)
+        if (nextEnd === -1)
           break;
 
         var text = data.substring(nextStart, nextEnd + 1);

--- a/lib/text/urls.js
+++ b/lib/text/urls.js
@@ -15,7 +15,7 @@ module.exports = function Urls() {
 
       for (; nextEnd < data.length; ) {
         nextStart = data.indexOf('url(', nextEnd);
-        if (nextStart == -1)
+        if (nextStart === -1)
           break;
 
         nextEnd = data.indexOf(')', nextStart);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "browser": false,
     "camelcase": true,
     "curly": false,
-    "eqeqeq": false,
+    "eqeqeq": true,
     "eqnull": true,
     "immed": true,
     "latedef": true,

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var assert = require('assert');
 var CleanCSS = require('../index');
 
-var lineBreak = process.platform == 'win32' ? /\r\n/g : /\n/g;
+var lineBreak = process.platform === 'win32' ? /\r\n/g : /\n/g;
 
 var batchContexts = function() {
   var context = {};

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var exec = require('child_process').exec;
 var fs = require('fs');
 
-var isWindows = process.platform == 'win32';
+var isWindows = process.platform === 'win32';
 var lineBreak = isWindows ? /\r\n/g : /\n/g;
 
 var binaryContext = function(options, context) {

--- a/test/unit-test.js
+++ b/test/unit-test.js
@@ -6,7 +6,7 @@ var path = require('path');
 var CleanCSS = require('../index');
 var ColorShortener = require('../lib/colors/shortener');
 
-var lineBreak = process.platform == 'win32' ? '\r\n' : '\n';
+var lineBreak = process.platform === 'win32' ? '\r\n' : '\n';
 var cssContext = function(groups, options) {
   var context = {};
   var clean = function(expectedCSS) {
@@ -24,7 +24,7 @@ var cssContext = function(groups, options) {
 
   for (var g in groups) {
     var transformation = groups[g];
-    if (typeof transformation == 'string')
+    if (typeof transformation === 'string')
       transformation = [transformation, transformation];
     if (!transformation[0].push)
       transformation = [[transformation[0], transformation[1]]];


### PR DESCRIPTION
I know we have discussed this in the past, but I really think enabling `eqeq` makes things simpler, at least.

Currently you use the strict comparison in a few places only. Instead of having to think when to use it, this is simpler.

It doesn't have any downsides and we are being consistent.

I also went ahead and fixed the warnings in bin/cleancss.
