### PR TITLE
Remove check for `process.hrtime()`.

### DIFF
--- a/test/bench.js
+++ b/test/bench.js
@@ -1,11 +1,6 @@
 var CleanCSS = require('../index');
 var path = require('path');
 
-if (!process.hrtime) {
-  console.log('process.hrtime() (node.js > 0.7.6) is required for benchmarking');
-  process.exit(1);
-}
-
 var benchDir = path.join(__dirname, 'data-bench');
 var cssData = require('fs').readFileSync(path.join(benchDir, 'complex.css'), 'utf8');
 


### PR DESCRIPTION
Node.js 0.8 is required already.
