### PR TITLE
box-shadow with three zeros compression 

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -305,7 +305,7 @@ var minify = function(data, callback) {
   replace(/background:(?:none|transparent)([;}])/g, 'background:0 0$1');
 
   // multiple zeros into one
-  replace(/box-shadow:0 0 0 0([^\.])/g, 'box-shadow:0 0$1');
+  replace(/box-shadow:0 0 0( 0)?([^\.])/g, 'box-shadow:0 0$2');
   replace(/:0 0 0 0([^\.])/g, ':0$1');
   replace(/([: ,=\-])0\.(\d)/g, '$1.$2');
 

--- a/test/unit-test.js
+++ b/test/unit-test.js
@@ -406,8 +406,12 @@ vows.describe('clean-units').addBatch({
       'div{clip:rect(0px 0px 0px 10px)}',
       'div{clip:rect(0 0 0 10px)}'
     ],
-    'box shadow zeros': [
+    'box shadow zeros with four zeros': [
       'a{box-shadow:0 0 0 0}',
+      'a{box-shadow:0 0}'
+    ],
+    'box shadow with three zeros ': [
+      'a{box-shadow:0 0 0}',
       'a{box-shadow:0 0}'
     ],
     'rems': [


### PR DESCRIPTION
The edge case will happen when someone is using `box-shadow: 0 0 0 0` instead of  `box-shadow:0 0 0 0`.

`box-shadow: 0 0 0 0` will not be compiled to expected `box-shadow:0 0`

Therefore, `box-shadow: 0 0 0 0` will be compressed following this rule `replace(/:0 0 0 0([^\.])/g, ':0$1');`, which will output invalid `box-shadow: 0`.
