### PR TITLE
Add support for multiple inputs from executable

### DIFF
--- a/bin/cleancss
+++ b/bin/cleancss
@@ -4,6 +4,7 @@ var util = require('util');
 var fs = require('fs');
 var path = require('path');
 var CleanCSS = require('../index');
+var Q = require('q');
 
 var commands = require('commander');
 
@@ -81,17 +82,27 @@ if (commands.debug)
 if (commands.timeout)
   cleanOptions.inliner = { timeout: parseFloat(commands.timeout) * 1000 };
 if (commands.args.length > 0) {
-  var source = commands.args[0];
+  var source = commands.args;
   options.source = source;
-  cleanOptions.relativeTo = path.dirname(path.resolve(source));
+  cleanOptions.relativeTo = path.dirname(path.resolve(source[0]));
 }
 
 // ... and do the magic!
 if (options.source) {
-  fs.readFile(options.source, 'utf8', function(error, data) {
-    if (error)
-      throw error;
-    minify(data);
+  var promises = options.source.map(function (src) {
+    var deferred = Q.defer();
+
+    fs.readFile(src, 'utf8', function(error, data) {
+      if (error)
+        throw error;
+      deferred.resolve(data);
+    });
+
+    return deferred.promise;
+  });
+
+  Q.all(promises).then(function (res) {
+    minify(res.join(''));
   });
 } else {
   var stdin = process.openStdin();

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test": "vows"
   },
   "dependencies": {
-    "commander": "2.1.x"
+    "commander": "2.1.x",
+    "q": "*"
   },
   "devDependencies": {
     "jshint": "2.4.x",


### PR DESCRIPTION
Sometimes, it is not optimal to rely on piping and cat/type to have multiple files as input for executable, thus it's nice to have it as a feature. Moreover, it's also nice to not have to worry about piping as such (nice-to-have situation).

In this scenario, I actually have a case where I cannot do piping because I'm running the command from a windows user that does not have the rights to do piping (yes, windows...) and it's quite tricky to find the proper user to get the right access to piping. Thus, this is a better workaround (which also looks nicer).
