### PR TITLE
Update JSHint to 2.5.0.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,6 @@
   "plusplus": false,
   "quotmark": "single",
   "strict": false,
-  "trailing": true,
   "undef": true,
   "unused": true
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "commander": "2.2.x"
   },
   "devDependencies": {
-    "jshint": "2.4.x",
+    "jshint": "2.5.x",
     "nock": "0.27.x",
     "vows": "0.7.x"
   },


### PR DESCRIPTION
`trailing` has been removed upstream.
