### PR TITLE
Allows width keywords for border-width for side normalization.

### DIFF
--- a/lib/properties/validator.js
+++ b/lib/properties/validator.js
@@ -3,11 +3,12 @@
 
 module.exports = (function () {
   // Regexes used for stuff
+  var widthKeywords = ['thin', 'thick', 'medium', 'inherit', 'initial'];
   var cssUnitRegexStr = '(\\-?\\.?\\d+\\.?\\d*(px|%|em|rem|in|cm|mm|ex|pt|pc|vw|vh|vmin|vmax|)|auto|inherit)';
   var cssFunctionNoVendorRegexStr = '[A-Z]+(\\-|[A-Z]|[0-9])+\\(([A-Z]|[0-9]|\\ |\\,|\\#|\\+|\\-|\\%|\\.)*\\)';
   var cssFunctionVendorRegexStr = '\\-(\\-|[A-Z]|[0-9])+\\(([A-Z]|[0-9]|\\ |\\,|\\#|\\+|\\-|\\%|\\.)*\\)';
   var cssFunctionAnyRegexStr = '(' + cssFunctionNoVendorRegexStr + '|' + cssFunctionVendorRegexStr + ')';
-  var cssUnitAnyRegexStr = '(none|' + cssUnitRegexStr + '|' + cssFunctionNoVendorRegexStr + '|' + cssFunctionVendorRegexStr + ')';
+  var cssUnitAnyRegexStr = '(none|' + widthKeywords.join('|') + '|' + cssUnitRegexStr + '|' + cssFunctionNoVendorRegexStr + '|' + cssFunctionVendorRegexStr + ')';
 
   var backgroundRepeatKeywords = ['repeat', 'no-repeat', 'repeat-x', 'repeat-y', 'inherit'];
   var backgroundAttachmentKeywords = ['inherit', 'scroll', 'fixed', 'local'];
@@ -15,7 +16,6 @@ module.exports = (function () {
   var listStyleTypeKeywords = ['armenian', 'circle', 'cjk-ideographic', 'decimal', 'decimal-leading-zero', 'disc', 'georgian', 'hebrew', 'hiragana', 'hiragana-iroha', 'inherit', 'katakana', 'katakana-iroha', 'lower-alpha', 'lower-greek', 'lower-latin', 'lower-roman', 'none', 'square', 'upper-alpha', 'upper-latin', 'upper-roman'];
   var listStylePositionKeywords = ['inside', 'outside', 'inherit'];
   var outlineStyleKeywords = ['auto', 'inherit', 'hidden', 'none', 'dotted', 'dashed', 'solid', 'double', 'groove', 'ridge', 'inset', 'outset'];
-  var outlineWidthKeywords = ['thin', 'thick', 'medium', 'inherit'];
 
   var validator = {
     isValidHexColor: function (s) {
@@ -90,7 +90,7 @@ module.exports = (function () {
       return outlineStyleKeywords.indexOf(s) >= 0;
     },
     isValidOutlineWidth: function (s) {
-      return validator.isValidUnit(s) || outlineWidthKeywords.indexOf(s) >= 0;
+      return validator.isValidUnit(s) || widthKeywords.indexOf(s) >= 0;
     },
     isValidVendorPrefixedValue: function (s) {
       return /^-([A-Za-z0-9]|-)*$/gi.test(s);

--- a/test/data/issue-305-min.css
+++ b/test/data/issue-305-min.css
@@ -1,0 +1,1 @@
+div{border-width:thin}

--- a/test/data/issue-305.css
+++ b/test/data/issue-305.css
@@ -1,0 +1,3 @@
+div {
+  border-width: thin;
+}


### PR DESCRIPTION
When not all sides are specified for things like border/padding/margin
it appears clean-css attempts to normalize the data
(i.e "2px 5px" -> "2px 5px 2px 5px"). This normalization appears to
only look for things matched to cssUnitAnyRegexStr. cssUnitAnyRegexStr
doesn't include width keywords.

The width keywords were already specified for validating outline width.
This commit renames that list to be more generic (just widthKeywords). It
then adds this list to the cssUnitAnyRegexStr regexp.

This commit fixes #305. In addition I added "initial" to the list of
width keywords to fix gruntjs/grunt-contrib-cssmin#103 which is the
issue that lead me to writing this patch. So this commit should solve
that as well.

I'm may be too loose here. Adding the width keywords to cssUnitAnyRegexStr
will also means it will parse the following even though it is not
valid CSS.

```
div {margin: medium}
```

I guess it depends on if this tool is designed to validate just enough to
minify or if it also provides more general purpose linting. I assume the
former so my looseness is ok.
