### PR TITLE
Fix #337 -- component importance.

### DIFF
--- a/lib/properties/override-compactor.js
+++ b/lib/properties/override-compactor.js
@@ -71,7 +71,7 @@ module.exports = (function () {
           if (can(matchingComponent.value, token.value)) {
             // The component can override the matching component in the shorthand
 
-            if (!token.isImportant) {
+            if (!token.isImportant || token.isImportant && matchingComponent.isImportant) {
               // The overriding component is non-important which means we can simply include it into the shorthand
               // NOTE: stuff that can't really be included, like inherit, is taken care of at the final step, not here
               matchingComponent.value = token.value;

--- a/test/data/issue-337-min.css
+++ b/test/data/issue-337-min.css
@@ -1,0 +1,1 @@
+div{background:#fff!important}

--- a/test/data/issue-337.css
+++ b/test/data/issue-337.css
@@ -1,0 +1,4 @@
+div {
+    background: #eeeeee !important;
+    background-color: #ffffff !important;
+}


### PR DESCRIPTION
If a matching component and the corresponding token are both important, treat it as if neither is.

Fixes issue #337
