### PR TITLE
Allow users to disable rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cleancss [options] source-file, [source-file, ...]
 --skip-advanced                 Disable advanced optimizations - selector & property merging,
                                 reduction, etc.
 --skip-aggressive-merging       Disable properties merging based on their order
---rounding-precision [N]        Rounds pixel values to `N` decimal places, defaults to 2
+--rounding-precision [N]        Rounds to `N` decimal places. -1 disables rounding. Defaults to 2.
 -c, --compatibility [ie7|ie8]   Force compatibility mode
 -d, --debug                     Shows debug information (minification time & compression efficiency)
 ```
@@ -146,7 +146,7 @@ CleanCSS constructor accepts a hash as a parameter, i.e.,
 * `rebase` - set to false to skip URL rebasing
 * `relativeTo` - path to __resolve__ relative `@import` rules and URLs
 * `root` - path to __resolve__ absolute `@import` rules and __rebase__ relative URLs
-* `roundingPrecision` - Rounding precision, defaults to 2.
+* `roundingPrecision` - rounding precision. `-1` to disables rounding. Defaults to `2`.
 * `target` - path to a folder or an output file to which __rebase__ all URLs
 
 ### How to use clean-css with build tools?

--- a/bin/cleancss
+++ b/bin/cleancss
@@ -25,7 +25,7 @@ commands
   .option('--skip-rebase', 'Disable URLs rebasing')
   .option('--skip-advanced', 'Disable advanced optimizations - selector & property merging, reduction, etc.')
   .option('--skip-aggressive-merging', 'Disable properties merging based on their order')
-  .option('--rounding-precision [n]', 'Rounds pixel values to `N` decimal places, defaults to 2', parseInt)
+  .option('--rounding-precision [n]', 'Rounds to `N` decimal places. -1 disables rounding. Defaults to 2.', parseInt)
   .option('-c, --compatibility [ie7|ie8]', 'Force compatibility mode')
   .option('-t, --timeout [seconds]', 'Per connection timeout when fetching remote @imports (defaults to 5 seconds)')
   .option('-d, --debug', 'Shows debug information (minification time & compression efficiency)');

--- a/lib/selectors/optimizers/simple.js
+++ b/lib/selectors/optimizers/simple.js
@@ -103,7 +103,7 @@ function zeroMinifier(_, value) {
 }
 
 function precisionMinifier(_, value, precisionOptions) {
-  if (value.indexOf('.') === -1)
+  if (precisionOptions.value === -1 || value.indexOf('.') === -1)
     return value;
 
   return value

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -306,6 +306,11 @@ exports.commandsSuite = vows.describe('binary commands').addBatch({
       'should keep 0 decimal places': function(error, stdout) {
         assert.equal(stdout, 'div{width:1px}');
       }
+    }),
+    disabled: pipedContext('div{width:0.12345px}', '--rounding-precision -1', {
+      'should keep all decimal places': function(error, stdout) {
+        assert.equal(stdout, 'div{width:.12345px}');
+      }
     })
   },
   'neighbour merging': {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -630,6 +630,12 @@ vows.describe('integration tests').addBatch({
       'div{transform:translateY(-418.5051px)}'
     ]
   }, { roundingPrecision: 4 }),
+  'floats disabled rounding': cssContext({
+    'does not round': [
+      'div{transform:translateY(-418.505123px)}',
+      'div{transform:translateY(-418.505123px)}'
+    ]
+  }, { roundingPrecision: -1 }),
   'colors': cssContext({
     'shorten rgb to standard hexadecimal format': [
       'a{ color:rgb(5, 10, 15) }',

--- a/test/selectors/optimizers/simple-test.js
+++ b/test/selectors/optimizers/simple-test.js
@@ -332,6 +332,22 @@ vows.describe(SimpleOptimizer)
     }, { roundingPrecision: 3 })
   )
   .addBatch(
+    propertyContext('rounding disabled', {
+      'pixels': [
+        'a{transform:translateY(123.31135px)}',
+        ['transform:translateY(123.31135px)']
+      ],
+      'percents': [
+        'a{left:20.1231%}',
+        ['left:20.1231%']
+      ],
+      'ems': [
+        'a{left:1.1231em}',
+        ['left:1.1231em']
+      ]
+    }, { roundingPrecision: -1 })
+  )
+  .addBatch(
     propertyContext('units', {
       'pixels': [
         'a{width:0px}',


### PR DESCRIPTION
`cleancss --rounding-precision -1` should disable rounding altogether.

The binary test I added is currently failing and I have no idea why. I'm sure one of you will spot the mistake right away.

I guess this could also be merged into the 2.2 branch.
