### PR TITLE
Exclude all problematic pseudo-classes from rule-merging

### DIFF
--- a/lib/utils/compatibility.js
+++ b/lib/utils/compatibility.js
@@ -13,7 +13,7 @@ var DEFAULTS = {
     },
     selectors: {
       ie7Hack: false, // *+html hack
-      special: /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\((ltr|rtl)\)|:first|:fullscreen|:left|:read-only|:read-write|:right)/ // special selectors which prevent merging
+      special: /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\([a-z-]*\)|:first(?![a-z-])|:fullscreen|:left|:read-only|:read-write|:right)/ // special selectors which prevent merging
     },
     units: {
       rem: true

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -2097,6 +2097,14 @@ title']{display:block}",
       'a:nth-of-type(1){color:red}b{color:red}',
       'a:nth-of-type(1),b{color:red}'
     ],
+    'rules with well-supported pseudo classes should be merged #3': [
+      'a:first-of-type{color:red}b{color:red}',
+      'a:first-of-type,b{color:red}'
+    ],
+    'rules with well-supported pseudo classes should be merged #4': [
+      'a:first-child{color:red}b{color:red}',
+      'a:first-child,b{color:red}'
+    ],
     'rules with prefixed pseudo classes should not be merged #1': [
       'a:-moz-full-screen{color:red}b{color:red}',
       'a:-moz-full-screen{color:red}b{color:red}'
@@ -2116,6 +2124,10 @@ title']{display:block}",
     'rules with not-so-well-supported pseudo classes should not be merged #3': [
       'a:right{color:red}b{color:red}',
       'a:right{color:red}b{color:red}'
+    ],
+    'rules with not-so-well-supported pseudo classes should not be merged #4': [
+      'a:first{color:red}b{color:red}',
+      'a:first{color:red}b{color:red}'
     ]
   }),
   'complex granular properties': cssContext({

--- a/test/utils/compatibility-test.js
+++ b/test/utils/compatibility-test.js
@@ -14,7 +14,7 @@ vows.describe(Compatibility)
         assert.isTrue(options.properties.merging);
         assert.isTrue(options.units.rem);
         assert.isTrue(options.colors.opacity);
-        assert.deepEqual(options.selectors.special, /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\((ltr|rtl)\)|:first|:fullscreen|:left|:read-only|:read-write|:right)/);
+        assert.deepEqual(options.selectors.special, /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\([a-z-]*\)|:first(?![a-z-])|:fullscreen|:left|:read-only|:read-write|:right)/);
       }
     },
     'not given': {
@@ -33,7 +33,7 @@ vows.describe(Compatibility)
         assert.isTrue(options.properties.merging);
         assert.isFalse(options.units.rem);
         assert.isTrue(options.colors.opacity);
-        assert.deepEqual(options.selectors.special, /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\((ltr|rtl)\)|:first|:fullscreen|:left|:read-only|:read-write|:right)/);
+        assert.deepEqual(options.selectors.special, /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\([a-z-]*\)|:first(?![a-z-])|:fullscreen|:left|:read-only|:read-write|:right)/);
       }
     }
   })
@@ -95,7 +95,7 @@ vows.describe(Compatibility)
         assert.isTrue(options.properties.merging);
         assert.isTrue(options.units.rem);
         assert.isTrue(options.colors.opacity);
-        assert.deepEqual(options.selectors.special, /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\((ltr|rtl)\)|:first|:fullscreen|:left|:read-only|:read-write|:right)/);
+        assert.deepEqual(options.selectors.special, /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\([a-z-]*\)|:first(?![a-z-])|:fullscreen|:left|:read-only|:read-write|:right)/);
       }
     },
     'as a complex string value without group': {
@@ -108,7 +108,7 @@ vows.describe(Compatibility)
         assert.isTrue(options.properties.merging);
         assert.isFalse(options.units.rem);
         assert.isTrue(options.colors.opacity);
-        assert.deepEqual(options.selectors.special, /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\((ltr|rtl)\)|:first|:fullscreen|:left|:read-only|:read-write|:right)/);
+        assert.deepEqual(options.selectors.special, /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\([a-z-]*\)|:first(?![a-z-])|:fullscreen|:left|:read-only|:read-write|:right)/);
       }
     }
   })


### PR DESCRIPTION
Here's the patch to exclude all seven problematic pseudo-classes from rule-merging as discussed in #390.
