### PR TITLE
Add AppVeyor for Windows tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![NPM version](https://img.shields.io/npm/v/clean-css.svg?style=flat)](https://www.npmjs.com/package/clean-css)
-[![Build Status](https://img.shields.io/travis/jakubpawlowicz/clean-css/master.svg?style=flat)](https://travis-ci.org/jakubpawlowicz/clean-css)
+[![Linux Build Status](https://img.shields.io/travis/jakubpawlowicz/clean-css/master.svg?style=flat&label=Linux%20build)](https://travis-ci.org/jakubpawlowicz/clean-css)
+[![Windows Build status](https://img.shields.io/appveyor/ci/jakubpawlowicz/clean-css/master.svg?style=flat&label=Windows%20build)](https://ci.appveyor.com/project/jakubpawlowicz/clean-css/branch/master)
 [![Dependency Status](https://img.shields.io/david/jakubpawlowicz/clean-css.svg?style=flat)](https://david-dm.org/jakubpawlowicz/clean-css)
 [![devDependency Status](https://img.shields.io/david/dev/jakubpawlowicz/clean-css.svg?style=flat)](https://david-dm.org/jakubpawlowicz/clean-css#info=devDependencies)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+# http://www.appveyor.com/docs/appveyor-yml
+
+version: "{build}"
+
+clone_depth: 10
+
+init:
+  - git config --global core.autocrlf true
+
+environment:
+  matrix:
+    - nodejs_version: 0.10
+    - nodejs_version: 0.12
+    - nodejs_version: 1.0
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+build: off
+
+test_script:
+  - node --version && npm --version
+  - npm test
+
+matrix:
+  fast_finish: true
+
+cache:
+  - C:\Users\appveyor\AppData\Roaming\npm-cache         # npm cache
+  - node_modules                                        # local npm modules


### PR DESCRIPTION
WIP until @jakubpawlowicz you add AppVeyor for the repository itself :)

Also, note that node.js 0.12 hasn't been deployed yet on AppVeyor. I have notified @FeodorFitsner so it shouldn't take long before it's been added.