### PR TITLE
bin/cleancss: use `console.log` instead of `util.puts`.

### DIFF
--- a/bin/cleancss
+++ b/bin/cleancss
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-var util = require('util');
 var fs = require('fs');
 var path = require('path');
 var CleanCSS = require('../index');
@@ -35,16 +34,16 @@ commands
   .option('-d, --debug', 'Shows debug information (minification time & compression efficiency)');
 
 commands.on('--help', function() {
-  util.puts('  Examples:\n');
-  util.puts('    %> cleancss one.css');
-  util.puts('    %> cleancss -o one-min.css one.css');
+  console.log('  Examples:\n');
+  console.log('    %> cleancss one.css');
+  console.log('    %> cleancss -o one-min.css one.css');
   if (isWindows) {
-    util.puts('    %> type one.css two.css three.css | cleancss -o merged-and-minified.css');
+    console.log('    %> type one.css two.css three.css | cleancss -o merged-and-minified.css');
   } else {
-    util.puts('    %> cat one.css two.css three.css | cleancss -o merged-and-minified.css');
-    util.puts('    %> cat one.css two.css three.css | cleancss | gzip -9 -c > merged-minified-and-gzipped.css.gz');
+    console.log('    %> cat one.css two.css three.css | cleancss -o merged-and-minified.css');
+    console.log('    %> cat one.css two.css three.css | cleancss | gzip -9 -c > merged-minified-and-gzipped.css.gz');
   }
-  util.puts('');
+  console.log('');
   process.exit();
 });
 


### PR DESCRIPTION
```
C:\Users\xmr\Desktop>node -v & npm -v
v0.12.0
2.5.1

C:\Users\xmr\Desktop\>cleancss --help

  Usage: cleancss [options] source-file, [source-file, ...]

  Options:

    -h, --help                     output usage information
    -v, --version                  output the version number
    -b, --keep-line-breaks         Keep line breaks
    --s0                           Remove all special comments, i.e. /*! comment */
    --s1                           Remove all special comments but the first one
    -r, --root [root-path]         Set a root path to which resolve absolute @import rules
    -o, --output [output-file]     Use [output-file] as output instead of STDOUT
    -s, --skip-import              Disable @import processing
    --skip-rebase                  Disable URLs rebasing
    --skip-advanced                Disable advanced optimizations - selector & property merging, reduction, etc.
    --skip-aggressive-merging      Disable properties merging based on their order
    --skip-media-merging           Disable @media merging
    --skip-restructuring           Disable restructuring optimizations
    --skip-shorthand-compacting    Disable shorthand compacting
    --rounding-precision [n]       Rounds to `N` decimal places. Defaults to 2. -1 disables rounding.
    -c, --compatibility [ie7|ie8]  Force compatibility mode (see Readme for advanced examples)
    --source-map                   Enables building input's source map
    -t, --timeout [seconds]        Per connection timeout when fetching remote @imports (defaults to 5 seconds)
    -d, --debug                    Shows debug information (minification time & compression efficiency)

util.puts: Use console.log instead
  Examples:

util.puts: Use console.log instead
    %> cleancss one.css
util.puts: Use console.log instead
    %> cleancss -o one-min.css one.css
util.puts: Use console.log instead
    %> type one.css two.css three.css | cleancss -o merged-and-minified.css
util.puts: Use console.log instead
```