### PR TITLE
Fixes #476 - keep import on top when restructuring

### DIFF
--- a/lib/selectors/optimizers/advanced.js
+++ b/lib/selectors/optimizers/advanced.js
@@ -634,6 +634,10 @@ AdvancedOptimizer.prototype.restructure = function (tokens) {
 
   var position = tokens[0] && tokens[0].kind == 'at-rule' && tokens[0].value.indexOf('@charset') === 0 ? 1 : 0;
   for (; position < tokens.length - 1; position++) {
+    if (!tokens[position] || tokens[position].kind != 'at-rule' || tokens[position].value.indexOf('@import') !== 0)
+      break;
+  }
+  for (; position < tokens.length - 1; position++) {
     if (!tokens[position] || tokens[position].kind != 'text' || tokens[position].value.indexOf('__ESCAPED_COMMENT_SPECIAL') !== 0)
       break;
   }

--- a/lib/selectors/optimizers/advanced.js
+++ b/lib/selectors/optimizers/advanced.js
@@ -634,11 +634,12 @@ AdvancedOptimizer.prototype.restructure = function (tokens) {
 
   var position = tokens[0] && tokens[0].kind == 'at-rule' && tokens[0].value.indexOf('@charset') === 0 ? 1 : 0;
   for (; position < tokens.length - 1; position++) {
-    if (!tokens[position] || tokens[position].kind != 'at-rule' || tokens[position].value.indexOf('@import') !== 0)
+    var isImportRule, isEscapedCommentSpecial;
+    if (!tokens[position])
       break;
-  }
-  for (; position < tokens.length - 1; position++) {
-    if (!tokens[position] || tokens[position].kind != 'text' || tokens[position].value.indexOf('__ESCAPED_COMMENT_SPECIAL') !== 0)
+    isImportRule = tokens[position].kind === 'at-rule' && tokens[position].value.indexOf('@import') === 0;
+    isEscapedCommentSpecial = tokens[position].kind === 'text' && tokens[position].value.indexOf('__ESCAPED_COMMENT_SPECIAL') === 0;
+    if (!( isImportRule || isEscapedCommentSpecial))
       break;
   }
 

--- a/test/selectors/optimizer-test.js
+++ b/test/selectors/optimizer-test.js
@@ -109,6 +109,10 @@ vows.describe(SelectorsOptimizer)
         '@charset "utf-8";a{width:100px}div{color:red}.one{display:block}.two{display:inline;color:red}',
         '@charset "utf-8";.two,div{color:red}a{width:100px}.one{display:block}.two{display:inline}'
       ],
+      'up until top with import': [
+        '@charset "UTF-8";@import url(http://fonts.googleapis.com/css?family=Lora:400,700);a{width:100px}div{color:red}.one{display:block}.two{display:inline;color:red}',
+        '@charset "UTF-8";@import url(http://fonts.googleapis.com/css?family=Lora:400,700);.two,div{color:red}a{width:100px}.one{display:block}.two{display:inline}'
+      ],
       'two at once': [
         '.one,.two,.three{color:red;display:block}div{margin:0}.four,.five,.six{color:red;display:block}',
         '.five,.four,.one,.six,.three,.two{color:red;display:block}div{margin:0}'


### PR DESCRIPTION
We had a problem when minimizing CSS with optimizations on but processing of import rules off. Some optimized selectors would end up above import rules, thus ignoring imported fonts in the generated CSS. This change fixes the problem in our environment.