### PR TITLE
add --skip-urls-processing option

### DIFF
--- a/bin/cleancss
+++ b/bin/cleancss
@@ -27,6 +27,7 @@ commands
   .option('--skip-media-merging', 'Disable @media merging')
   .option('--skip-restructuring', 'Disable restructuring optimizations')
   .option('--skip-shorthand-compacting', 'Disable shorthand compacting')
+  .option('--skip-urls-processing', 'Skip urls processing (e.g. url unquoting)')
   .option('--rounding-precision [n]', 'Rounds to `N` decimal places. Defaults to 2. -1 disables rounding.', parseInt)
   .option('-c, --compatibility [ie7|ie8]', 'Force compatibility mode (see Readme for advanced examples)')
   .option('--source-map', 'Enables building input\'s source map')
@@ -73,6 +74,7 @@ var options = {
   root: commands.root,
   roundingPrecision: commands.roundingPrecision,
   shorthandCompacting: commands.skipShorthandCompacting ? false : true,
+  urlsProcessing: commands.skipUrlsProcessing ? false : true,
   sourceMap: commands.sourceMap,
   sourceMapInlineSources: commands.sourceMapInlineSources,
   target: commands.output

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -48,6 +48,7 @@ var CleanCSS = module.exports = function CleanCSS(options) {
     root: options.root || process.cwd(),
     roundingPrecision: options.roundingPrecision,
     shorthandCompacting: !!options.sourceMap ? false : (undefined === options.shorthandCompacting ? true : !!options.shorthandCompacting),
+    urlProcessing: undefined === options.urlProcessing ? true : !!options.urlProcessing,
     sourceMap: options.sourceMap,
     sourceMapInlineSources: !!options.sourceMapInlineSources,
     target: options.target && fs.existsSync(options.target) && fs.statSync(options.target).isDirectory() ? options.target : path.dirname(options.target)
@@ -175,13 +176,16 @@ function minify(context, data) {
 
   run(commentsProcessor, 'escape');
   run(expressionsProcessor, 'escape');
-  run(urlsProcessor, 'escape');
+  
+  if (options.urlsProcessing)
+    run(urlsProcessor, 'escape');
+  
   run(freeTextProcessor, 'escape');
 
   run(function() {
     var stringifier = new stringifierClass(options, function (data) {
       data = freeTextProcessor.restore(data);
-      data = urlsProcessor.restore(data);
+      data = options.urlsProcessing ? urlsProcessor.restore(data) : data;
       data = options.rebase ? urlRebase.process(data) : data;
       data = expressionsProcessor.restore(data);
       return commentsProcessor.restore(data);

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -135,6 +135,11 @@ exports.commandsSuite = vows.describe('binary commands').addBatch({
       assert.equal(stdout, 'div{margin-top:0}.one{margin:0}.two{display:block;margin-top:0}');
     }
   }),
+  'skip urls processing': pipedContext("div{background:url('route/to/myresource.png')}", '--skip-urls-processing', {
+    'should skip urls processing': function(error, stdout) {
+      assert.equal(stdout, "div{background:url('route/to/myresource.png')}");
+    }
+  }),
   'no relative to path': binaryContext('./test/fixtures/partials-absolute/base.css', {
     'should not be able to resolve it fully': function(error, stdout, stderr) {
       assert.isEmpty(stdout);

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -135,9 +135,9 @@ exports.commandsSuite = vows.describe('binary commands').addBatch({
       assert.equal(stdout, 'div{margin-top:0}.one{margin:0}.two{display:block;margin-top:0}');
     }
   }),
-  'skip urls processing': pipedContext("div{background:url('route/to/myresource.png')}", '--skip-urls-processing', {
+  'skip urls processing': pipedContext('div{background:url(\'route/to/myresource.png\')}', '--skip-urls-processing', {
     'should skip urls processing': function(error, stdout) {
-      assert.equal(stdout, "div{background:url('route/to/myresource.png')}");
+      assert.equal(stdout, 'div{background:url(\'route/to/myresource.png\')}');
     }
   }),
   'no relative to path': binaryContext('./test/fixtures/partials-absolute/base.css', {


### PR DESCRIPTION
UrlsProcessor is quite useful when producing straight production css code, but it causes a lot of trouble when used with a resources filter in a java servlet container (and from what I see on previous issues I would say it does cause trouble in other contexts too).

For example if I want to generate a css like: 

´´´
div{background:url(#{resource['path/to/my/resource.jpg']})}
´´´

(which is perfectly valid production code on JSF using omnifaces' UnmappedResourceHandler)

the UrlProcessor removes the quotes from the url, turning it into:

´´´
div{background:url(#{resource[path/to/my/resource.jpg]})}
´´´

which produces an error when the JSF servlet's resource handler cannot resolve the requested resource and produce a valid css file upon request.

A nice and simple solution could be having an option to disable the UrlsProcessor, --skip-urls-processing, which is what the commits on the pull request do.