### PR TITLE
Support ingestion of inline, data-uri sourcemaps in input .css

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+[3.3.1 / 2015-xx-xx](https://github.com/jakubpawlowicz/clean-css/compare/v3.3.0...3.3)
+==================
+
+* Fixed issue [#590](https://github.com/jakubpawlowicz/clean-css/issues/590) - edge case in `@import` processing.
+
 [3.3.0 / 2015-05-31](https://github.com/jakubpawlowicz/clean-css/compare/v3.2.11...v3.3.0)
 ==================
 

--- a/History.md
+++ b/History.md
@@ -1,4 +1,4 @@
-[3.3.1 / 2015-xx-xx](https://github.com/jakubpawlowicz/clean-css/compare/v3.3.0...3.3)
+[3.3.1 / 2015-06-02](https://github.com/jakubpawlowicz/clean-css/compare/v3.3.0...v3.3.1)
 ==================
 
 * Fixed issue [#590](https://github.com/jakubpawlowicz/clean-css/issues/590) - edge case in `@import` processing.

--- a/lib/urls/reduce.js
+++ b/lib/urls/reduce.js
@@ -59,28 +59,30 @@ function byUrl(data, context, callback) {
 }
 
 function byImport(data, context, callback) {
+  var nextImport = 0;
+  var nextImportUpperCase = 0;
   var nextStart = 0;
-  var nextStartUpperCase = 0;
   var nextEnd = 0;
   var cursor = 0;
   var tempData = [];
   var nextSingleQuote = 0;
   var nextDoubleQuote = 0;
+  var untilNextQuote;
   var withQuote;
   var SINGLE_QUOTE = '\'';
   var DOUBLE_QUOTE = '"';
 
   for (; nextEnd < data.length;) {
-    nextStart = data.indexOf(IMPORT_URL_PREFIX, nextEnd);
-    nextStartUpperCase = data.indexOf(UPPERCASE_IMPORT_URL_PREFIX, nextEnd);
-    if (nextStart == -1 && nextStartUpperCase == -1)
+    nextImport = data.indexOf(IMPORT_URL_PREFIX, nextEnd);
+    nextImportUpperCase = data.indexOf(UPPERCASE_IMPORT_URL_PREFIX, nextEnd);
+    if (nextImport == -1 && nextImportUpperCase == -1)
       break;
 
-    if (nextStart > -1 && nextStartUpperCase > -1 && nextStartUpperCase < nextStart)
-      nextStart = nextStartUpperCase;
+    if (nextImport > -1 && nextImportUpperCase > -1 && nextImportUpperCase < nextImport)
+      nextImport = nextImportUpperCase;
 
-    nextSingleQuote = data.indexOf(SINGLE_QUOTE, nextStart);
-    nextDoubleQuote = data.indexOf(DOUBLE_QUOTE, nextStart);
+    nextSingleQuote = data.indexOf(SINGLE_QUOTE, nextImport);
+    nextDoubleQuote = data.indexOf(DOUBLE_QUOTE, nextImport);
 
     if (nextSingleQuote > -1 && nextDoubleQuote > -1 && nextSingleQuote < nextDoubleQuote) {
       nextStart = nextSingleQuote;
@@ -94,12 +96,15 @@ function byImport(data, context, callback) {
     } else if (nextDoubleQuote > -1) {
       nextStart = nextDoubleQuote;
       withQuote = DOUBLE_QUOTE;
+    } else {
+      break;
     }
 
     tempData.push(data.substring(cursor, nextStart));
-
     nextEnd = data.indexOf(withQuote, nextStart + 1);
-    if (nextEnd == -1) {
+
+    untilNextQuote = data.substring(nextImport, nextEnd);
+    if (nextEnd == -1 || /^@import\s+(url\(|__ESCAPED)/i.test(untilNextQuote)) {
       cursor = nextStart;
       break;
     }

--- a/lib/utils/input-source-map-tracker.js
+++ b/lib/utils/input-source-map-tracker.js
@@ -5,11 +5,14 @@ var path = require('path');
 var http = require('http');
 var https = require('https');
 var url = require('url');
+var dataUriToBuffer = require('data-uri-to-buffer');
+var getCharset = require('http-buffer-charset');
 
 var override = require('../utils/object.js').override;
 
 var MAP_MARKER = /\/\*# sourceMappingURL=(\S+) \*\//;
 var REMOTE_RESOURCE = /^(https?:)?\/\//;
+var DATA_URI = /^data:.*,/;
 
 function InputSourceMapStore(outerContext) {
   this.options = outerContext.options;
@@ -63,15 +66,26 @@ function fromSource(self, data, whenDone, context) {
       context.files.pop();
     } else if (nextAt == mapMatch.index) {
       var isRemote = /^https?:\/\//.test(sourceMapFile) || /^\/\//.test(sourceMapFile);
+      var isDataUri = DATA_URI.test(sourceMapFile);
       if (isRemote) {
         return fetchMapFile(self, sourceMapFile, context, proceedToNext);
       } else {
         var sourceFile = context.files[context.files.length - 1];
-        var sourceDir = sourceFile ? path.dirname(sourceFile) : self.options.relativeTo;
-        var sourceMapPath = path.resolve(self.options.root, path.join(sourceDir || '', sourceMapFile));
-
-        var sourceMapData = fs.readFileSync(sourceMapPath, 'utf-8');
-        self.trackLoaded(sourceFile || undefined, sourceMapPath, sourceMapData);
+        var sourceMapPath, sourceMapData;
+        if(isDataUri) {
+          // source map's path is the same as the source file it comes from
+          sourceMapPath = path.resolve(self.options.root, sourceFile);
+          var buffer = dataUriToBuffer(sourceMapFile);
+          var charset = getCharset(buffer.charset);
+          if(!charset) throw new Error('Unsupported character encoding.');
+          sourceMapData = buffer.toString(charset);
+          self.trackLoaded(sourceFile || undefined, sourceMapPath, sourceMapData);
+        } else {
+          var sourceDir = sourceFile ? path.dirname(sourceFile) : self.options.relativeTo;
+          sourceMapPath = path.resolve(self.options.root, path.join(sourceDir || '', sourceMapFile));
+          sourceMapData = fs.readFileSync(sourceMapPath, 'utf-8');
+          self.trackLoaded(sourceFile || undefined, sourceMapPath, sourceMapData);
+        }
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   },
   "dependencies": {
     "commander": "2.8.x",
+    "data-uri-to-buffer": "0.0.3",
+    "http-buffer-charset": "0.0.3",
     "source-map": "0.4.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,6 @@
   },
   "engines": {
     "node": ">=0.10.0"
-  }
+  },
+  "source-map-data-uri": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-css",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": "Jakub Pawlowicz <contact@jakubpawlowicz.com> (http://twitter.com/jakubpawlowicz)",
   "description": "A well-tested CSS minifier",
   "license": "MIT",

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1674,6 +1674,12 @@ title']{display:block}",
     ],
     'no empty body': '@import url(//fonts.googleapis.com/css?family=Domine:700);body{color:red}body h1{font-family:Domine}'
   }, { processImport: false, advanced: false }),
+  '@import with no url': cssContext({
+    'matching too much': [
+      '@import url(test.css);@font-face{font-family:"icomoon"}',
+      '@import url(test.css);@font-face{font-family:icomoon}'
+    ]
+  }, { processImport: false, root: process.cwd(), relativeTo: process.cwd() }),
   'duplicate selectors with disabled advanced processing': cssContext({
     'of a duplicate selector': [
       'a,a{color:red}',


### PR DESCRIPTION
This patch enables clean-css to ingest sourcemaps within input .css files where the sourcemap is an inline data URI.