### PR TITLE
Updates README.md plugin list with lasso-clean-css

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ If you don't provide a callback, then remote `@import`s will be left intact.
 * [Gulp](http://gulpjs.com/): [using vinyl-map as a wrapper - courtesy of @sogko](https://github.com/jakubpawlowicz/clean-css/issues/342)
 * [component-builder2](https://github.com/component/builder2.js): [builder-clean-css](https://github.com/poying/builder-clean-css)
 * [Metalsmith](http://metalsmith.io): [metalsmith-clean-css](https://github.com/aymericbeaumet/metalsmith-clean-css)
+* [Lasso](https://github.com/lasso-js/lasso): [lasso-clean-css](https://github.com/yomed/lasso-clean-css)
 
 ### What are the clean-css' dev commands?
 


### PR DESCRIPTION
I've created a clean-css plugin for use with the [Lasso.js](https://github.com/lasso-js/lasso) module bundler, and added a reference to it in the plugin list section of the clean-css documentation in this PR.