### PR TITLE
Allow users to set proxy for @import through proxy.

### DIFF
--- a/lib/imports/inliner.js
+++ b/lib/imports/inliner.js
@@ -248,6 +248,9 @@ function inlineRemoteResource(importedFile, mediaQuery, context) {
   }
 
   var requestOptions = override(url.parse(importedUrl), context.inliner.request);
+  if (context.inliner.request.hostname !== undefined) {
+    requestOptions.path = requestOptions.href;
+  }
   get(requestOptions, function (res) {
     if (res.statusCode < 200 || res.statusCode > 399) {
       return handleError('error ' + res.statusCode);


### PR DESCRIPTION
Trying to solve issue #612 I made minimum modifications.

In order to get it work with my authenticated proxy I have to call:
```javascript
minifyCss({
    inliner: {
        request: {
            hostname: proxy.hostname,
            port: proxy.port,
            // If not an authenticated proxy you should remove 'headers' attribute
            headers: {
                'Proxy-Authorization': 'Basic ' + new Buffer(proxy.username + ':' + proxy.password).toString('base64')
            }
        }
    }
})
```

Example:
```javascript
var proxy = {
    hostname: 'myproxy.com',
    port: 8080,
    username: 'user',
    password: 'password'
}
```

For me these modifications make it works. Some people add 'Host' in headers but it make no difference for me. Maybe someone who really knows which headers matter could add what is usually needed until that I prefer keeping it simple.

Otherwise it is not a really proper exposed manner to handle proxies but I prefer letting you expose proxy API the way you think it is the best. Maybe it is possible to get npm proxy configuration...

HTH.