### PR TITLE
Always quote data urls during rewrite.

### DIFF
--- a/lib/urls/rewrite.js
+++ b/lib/urls/rewrite.js
@@ -48,6 +48,9 @@ function normalize(uri) {
 }
 
 function rebase(uri, options) {
+  if (isData(uri))
+    return '\'' + uri + '\'';
+
   if (isAbsolute(uri) || isSVGMarker(uri) || isEscaped(uri) || isInternal(uri))
     return uri;
 
@@ -56,9 +59,6 @@ function rebase(uri, options) {
 
   if (!options.imports && isImport(uri))
     return uri;
-
-  if (isData(uri))
-    return '\'' + uri + '\'';
 
   if (isRemote(uri) && !isRemote(options.toBase))
     return uri;

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -15,7 +15,7 @@ var binaryContext = function (options, context) {
   if (isWindows)
     return {};
 
-  context.topic = function () {
+    context.topic = function () {
     // We add __DIRECT__=1 to force binary into 'non-piped' mode
     exec('__DIRECT__=1 ./bin/cleancss ' + options, this.callback);
   };
@@ -259,6 +259,15 @@ vows.describe('./bin/cleancss')
         },
         teardown: function () {
           deleteFile('./base2-min.css');
+        }
+      }),
+      'data url': binaryContext('-r ./test/fixtures -o ./data-min.css ./test/fixtures/partials-relative/data.css', {
+        'should rewrite data urls quoted': function () {
+          var minimized = readFile('./data-min.css');
+          assert.equal(minimized, 'a{background-image:url(\'data:svg+xml,SGV_DATA\')}');
+        },
+        teardown: function () {
+          deleteFile('./data-min.css');
         }
       }),
       'piped with output': pipedContext('a{background:url(test/fixtures/partials/extra/down.gif)}', '-o base3-min.css', {

--- a/test/fixtures/partials-relative/data.css
+++ b/test/fixtures/partials-relative/data.css
@@ -1,0 +1,3 @@
+a {
+  background-image: url('data:svg+xml,SGV_DATA');
+}


### PR DESCRIPTION
When using clean-css with the gulp-minify-css plugin URLs are re-written in source-reader.js#fromHash.

For an inline svg image like 

```css
div {
  background-image: url('data:svg+xml,SGV_DATA');
}
```
the quotes are stripped rewrite.js, because isInternal(uri) matches and isData(uri) never executes.

Executing the isData(uri) check at the beginning seems to fix the issue.

(IE9 does not like url(data:) without quotes)