### PR TITLE
fix #701 properties.urlQuotes doesn't work

### DIFF
--- a/lib/urls/rewrite.js
+++ b/lib/urls/rewrite.js
@@ -91,9 +91,16 @@ function quoteFor(url) {
 }
 
 function rewriteUrls(data, options, context) {
-  return reduceUrls(data, context, function (url, tempData) {
-    url = url.replace(/^(url\()?\s*['"]?|['"]?\s*\)?$/g, '');
-    tempData.push('url(' + quoteFor(url) + rebase(url, options) + quoteFor(url) + ')');
+  return reduceUrls(data, context, function (originUrl, tempData) {
+    var url = originUrl.replace(/^(url\()?\s*['"]?|['"]?\s*\)?$/g, '');
+    var match = originUrl.match(/^(url\()?\s*(['"]).*?(['"])\s*\)?$/);
+    var quote;
+    if (!!options.urlQuotes && match && match[2] === match[3]) {
+      quote = match[2];
+    } else {
+      quote = quoteFor(url);
+    }
+    tempData.push('url(' + quote + rebase(url, options) + quote + ')');
   });
 }
 

--- a/lib/utils/source-reader.js
+++ b/lib/utils/source-reader.js
@@ -74,7 +74,8 @@ function fromHash(self) {
       imports: true,
       rebase: self.outerContext.options.rebase,
       fromBase: absoluteSourcePath,
-      toBase: isRemote ? absoluteSourcePath : toBase
+      toBase: isRemote ? absoluteSourcePath : toBase,
+      urlQuotes: self.outerContext.options.compatibility.properties.urlQuotes
     };
     styles = rewriteUrls(styles, rewriteOptions, self.outerContext);
 

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1366,6 +1366,18 @@ vows.describe('integration tests')
       'keeps quotes as they are': [
         'div{background:url("test.png")}',
         'div{background:url("test.png")}'
+      ],
+      'keeps quotes as they are when minify hash data': [
+        {'temp/file.css': {
+          styles: 'div{background:url("test.png")}'
+        }},
+        'div{background:url("temp/test.png")}'
+      ],
+      'no quotes added when minify hash data': [
+        {'temp/file.css': {
+          styles: 'div{background:url(test.png)}'
+        }},
+        'div{background:url(temp/test.png)}'
       ]
     }, { compatibility: { properties: { urlQuotes: true } } })
   )


### PR DESCRIPTION
Prevent SourceReader to remove all quote in `url()`