### PR TITLE
fix proxy issues on https @imports with request

### DIFF
--- a/lib/imports/inliner.js
+++ b/lib/imports/inliner.js
@@ -281,7 +281,12 @@ function inlineRemoteResource(importedFile, mediaQuery, context) {
     });
   }
 
-  if(context.inliner.request) {
+  var requestOptions = {
+    url: importedUrl,
+    timeout: context.inliner.timeout
+  };
+
+  if(context.inliner.request && context.inliner.request.hostname) {
     var proxyURL =
       (context.inliner.request.protocol &&
        context.inliner.request.protocol.indexOf('https://') === 0) ?
@@ -290,15 +295,18 @@ function inlineRemoteResource(importedFile, mediaQuery, context) {
 
     proxyURL += context.inliner.request.hostname;
     proxyURL += (context.inliner.request.port) ?
-      ':' + context.inliner.request :
+      ':' + context.inliner.request.port :
       '';
 
-    request.defaults({ proxy: proxyURL });
+    requestOptions.proxy = proxyURL;
+    requestOptions.tunnel = context.inliner.request.tunnel === true;
   }
 
-  request.get(importedUrl, {
-    timeout: context.inliner.timeout
-  })
+  requestOptions.method = (!context.inliner.request.method) ?
+    'GET' :
+    context.inliner.request.method;
+
+  request(requestOptions)
   .on('response', function (res) {
 
     if (res.statusCode < 200 || res.statusCode > 399) {

--- a/lib/imports/inliner.js
+++ b/lib/imports/inliner.js
@@ -1,7 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var http = require('http');
-var https = require('https');
+var request = require('request');
 var url = require('url');
 
 var rewriteUrls = require('../urls/rewrite');
@@ -268,10 +267,6 @@ function inlineRemoteResource(importedFile, mediaQuery, context) {
 
   context.visited.push(importedUrl);
 
-  var get = importedUrl.indexOf('http://') === 0 ?
-    http.get :
-    https.get;
-
   var errorHandled = false;
   function handleError(message) {
     if (errorHandled)
@@ -286,11 +281,26 @@ function inlineRemoteResource(importedFile, mediaQuery, context) {
     });
   }
 
-  var requestOptions = override(url.parse(importedUrl), context.inliner.request);
-  if (context.inliner.request.hostname !== undefined)
-    requestOptions.path = requestOptions.href;
+  if(context.inliner.request) {
+    var proxyURL =
+      (context.inliner.request.protocol &&
+       context.inliner.request.protocol.indexOf('https://') === 0) ?
+      'https://' :
+      'http://';
 
-  get(requestOptions, function (res) {
+    proxyURL += context.inliner.request.hostname;
+    proxyURL += (context.inliner.request.port) ?
+      ':' + context.inliner.request :
+      '';
+
+    request.defaults({ proxy: proxyURL });
+  }
+
+  request.get(importedUrl, {
+    timeout: context.inliner.timeout
+  })
+  .on('response', function (res) {
+
     if (res.statusCode < 200 || res.statusCode > 399) {
       return handleError('error ' + res.statusCode);
     } else if (res.statusCode > 299) {
@@ -331,8 +341,7 @@ function inlineRemoteResource(importedFile, mediaQuery, context) {
   })
   .on('timeout', function () {
     handleError('timeout');
-  })
-  .setTimeout(context.inliner.timeout);
+  });
 }
 
 function inlineLocalResource(importedFile, mediaQuery, context) {

--- a/lib/imports/inliner.js
+++ b/lib/imports/inliner.js
@@ -340,7 +340,7 @@ function inlineRemoteResource(importedFile, mediaQuery, context) {
     handleError(res.message);
   })
   .on('timeout', function () {
-    handleError('timeout');
+    handleError('ETIMEDOUT');
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "commander": "2.9.x",
+    "request": "^2.69.0",
     "source-map": "0.5.x"
   },
   "devDependencies": {

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -350,7 +350,7 @@ vows.describe('./bin/cleancss')
         });
       },
       'should raise warning': function (error, stdout, stderr) {
-        assert.include(stderr, 'Broken @import declaration of "http://localhost:24682/timeout.css" - timeout');
+        assert.include(stderr, 'Broken @import declaration of "http://localhost:24682/timeout.css" - ETIMEDOUT');
       },
       'should output empty response': function (error, stdout) {
         assert.isEmpty(stdout);

--- a/test/protocol-imports-test.js
+++ b/test/protocol-imports-test.js
@@ -538,7 +538,7 @@ vows.describe('protocol imports').addBatch({
     },
     'should raise errors': function (errors, minified) {
       assert.lengthOf(errors, 1);
-      assert.equal(errors[0], 'Broken @import declaration of "http://localhost:' + port + '/timeout.css" - timeout');
+      assert.equal(errors[0], 'Broken @import declaration of "http://localhost:' + port + '/timeout.css" - ETIMEDOUT');
     },
     'should process @import': function (errors, minified) {
       assert.equal(minified.styles, '@import url(http://localhost:' + port + '/timeout.css);a{color:red}');


### PR DESCRIPTION
When an @import used a https url, the false protocol was tried to be used for the http proxy.

Additionally request has replaced a direct http.get and https.get call, to automatically handle proxy environment variables
and other possible edge cases.

fixes #741