### PR TITLE
fix proxy issues on https @imports

### DIFF
--- a/lib/imports/inliner.js
+++ b/lib/imports/inliner.js
@@ -268,7 +268,10 @@ function inlineRemoteResource(importedFile, mediaQuery, context) {
 
   context.visited.push(importedUrl);
 
-  var get = importedUrl.indexOf('http://') === 0 ?
+  var proxyProtocol = context.inliner.request.protocol || context.inliner.request.hostname;
+  var get =
+    ((proxyProtocol && proxyProtocol.indexOf('https://') !== 0 ) ||
+     importedUrl.indexOf('http://') === 0) ?
     http.get :
     https.get;
 
@@ -287,8 +290,13 @@ function inlineRemoteResource(importedFile, mediaQuery, context) {
   }
 
   var requestOptions = override(url.parse(importedUrl), context.inliner.request);
-  if (context.inliner.request.hostname !== undefined)
+  if (context.inliner.request.hostname !== undefined) {
+
+    //overwrite as we always expect a http proxy currently
+    requestOptions.protocol = context.inliner.request.protocol || 'http:';
     requestOptions.path = requestOptions.href;
+  }
+
 
   get(requestOptions, function (res) {
     if (res.statusCode < 200 || res.statusCode > 399) {


### PR DESCRIPTION
When an @import used a https url, the false protocol was tried to be used for the http proxy.

fixes #741