### PR TITLE
avoid calling path.dirname(sourceFile=undefined)

### DIFF
--- a/lib/utils/input-source-map-tracker.js
+++ b/lib/utils/input-source-map-tracker.js
@@ -184,11 +184,12 @@ function trackContentSources(self, sourceFile) {
   var consumer = self.maps[sourceFile].data;
   var isRemote = REMOTE_RESOURCE.test(sourceFile);
   var sourcesMapping = {};
+  var sourceDir = sourceFile ? path.dirname(sourceFile) : self.relativeTo;
 
   consumer.sources.forEach(function (file, index) {
     var uniquePath = isRemote ?
-      url.resolve(path.dirname(sourceFile), file) :
-      path.relative(self.relativeTo, path.resolve(path.dirname(sourceFile), file));
+      url.resolve(sourceDir, file) :
+      path.relative(self.relativeTo, path.resolve(sourceDir, file));
 
     sourcesMapping[uniquePath] = consumer.sourcesContent && consumer.sourcesContent[index];
   });


### PR DESCRIPTION
This happens when fromString is called, and fails on node v6.
The apparent fix is to use `sourceDir=relativeTo` when sourceFile is undefined, as is already done in fromSource.

Failing example with less:

```javascript
var CleanCSS = require('clean-css'),
    less = require('less');

less.render('.class { width: (1 + 1) }', {sourceMap: {}}
  ).then(function (output) {
    var clean = new CleanCSS({sourceMap: output.map}).minify(output.css);
    console.log(clean);
  }).catch(function (err) {
    console.error(err);
  });
```

Or apparently any call to `lessc --clean-css --source-map ...` with node 6, failing with:

```
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:1324:5)
    at ./node_modules/clean-css/lib/utils/input-source-map-tracker.js:191:56
    at Array.forEach (native)
    at trackContentSources (./node_modules/clean-css/lib/utils/input-source-map-tracker.js:188:20)
    at InputSourceMapStore.trackLoaded (./node_modules/clean-css/lib/utils/input-source-map-tracker.js:255:3)
    at fromString (./node_modules/clean-css/lib/utils/input-source-map-tracker.js:32:8)
    at InputSourceMapStore.track (./node_modules/clean-css/lib/utils/input-source-map-tracker.js:236:5)
    at ./node_modules/clean-css/lib/clean.js:145:44
    at CleanCSS.minify (./node_modules/clean-css/lib/clean.js:127:42)
```