### PR TITLE
Prevent rules with :selection from being merged

### DIFF
--- a/lib/utils/compatibility.js
+++ b/lib/utils/compatibility.js
@@ -22,7 +22,7 @@ var DEFAULTS = {
     selectors: {
       adjacentSpace: false, // div+ nav Android stock browser hack
       ie7Hack: false, // *+html hack
-      special: /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\([a-z-]*\)|:first(?![a-z-])|:fullscreen|:left|:read-only|:read-write|:right|:placeholder|:host|::content|\/deep\/|::shadow|^,)/ // special selectors which prevent merging
+      special: /(\-moz\-|\-ms\-|\-o\-|\-webkit\-|:dir\([a-z-]*\)|:first(?![a-z-])|:fullscreen|:left|:read-only|:read-write|:right|:placeholder|:host|:content|\/deep\/|:shadow|:selection|^,)/ // special selectors which prevent merging
     },
     units: {
       ch: true,

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -2467,6 +2467,10 @@ vows.describe('integration tests')
         ':placeholder{color:red}b{color:red}',
         ':placeholder{color:red}b{color:red}'
       ],
+      'rules with not-so-well-supported pseudo classes should not be merged #6': [
+        ':selection{color:red}b{color:red}',
+        ':selection{color:red}b{color:red}'
+      ],
       'rules with :host Polymer pseudo class should not be merged into': [
         ':host{color:red}b{color:red}',
         ':host{color:red}b{color:red}'


### PR DESCRIPTION
Firefox does not support `:selection`, only `:-moz-selection`. This change adds `:selection` to the list of problematic selectors to prevent invalid rules from being created.

Also cleaned up the regex, `:` and `::` are equivalent in this regex, so reduced all section to just `:`.