### PR TITLE
Strenghten handling of rounding-precision option

### DIFF
--- a/bin/cleancss
+++ b/bin/cleancss
@@ -74,7 +74,7 @@ var options = {
   rebase: commands.skipRebase ? false : true,
   restructuring: commands.skipRestructuring ? false : true,
   root: commands.root,
-  roundingPrecision: commands.roundingPrecision === undefined ? undefined : parseInt(commands.roundingPrecision),
+  roundingPrecision: commands.roundingPrecision,
   semanticMerging: commands.semanticMerging ? true : false,
   shorthandCompacting: commands.skipShorthandCompacting ? false : true,
   sourceMap: commands.sourceMap,

--- a/bin/cleancss
+++ b/bin/cleancss
@@ -22,7 +22,7 @@ commands
   .option('-r, --root [root-path]', 'Set a root path to which resolve absolute @import rules')
   .option('-s, --skip-import', 'Disable @import processing')
   .option('-t, --timeout [seconds]', 'Per connection timeout when fetching remote @imports (defaults to 5 seconds)')
-  .option('--rounding-precision [n]', 'Rounds pixel values to `N` decimal places. Defaults to 2. -1 disables rounding', parseInt)
+  .option('--rounding-precision [n]', 'Rounds pixel values to `N` decimal places. Defaults to 2. -1 disables rounding')
   .option('--s0', 'Remove all special comments, i.e. /*! comment */')
   .option('--s1', 'Remove all special comments but the first one')
   .option('--semantic-merging', 'Enables unsafe mode by assuming BEM-like semantic stylesheets (warning, this may break your styling!)')
@@ -74,7 +74,7 @@ var options = {
   rebase: commands.skipRebase ? false : true,
   restructuring: commands.skipRestructuring ? false : true,
   root: commands.root,
-  roundingPrecision: commands.roundingPrecision,
+  roundingPrecision: commands.roundingPrecision === undefined ? undefined : parseInt(commands.roundingPrecision),
   semanticMerging: commands.semanticMerging ? true : false,
   shorthandCompacting: commands.skipShorthandCompacting ? false : true,
   sourceMap: commands.sourceMap,

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -55,7 +55,7 @@ var CleanCSS = module.exports = function CleanCSS(options) {
     relativeTo: options.relativeTo,
     restructuring: undefined === options.restructuring ? true : !!options.restructuring,
     root: options.root || process.cwd(),
-    roundingPrecision: undefined === options.roundingPrecision ? undefined : parseInt(options.roundingPrecision),
+    roundingPrecision: options.roundingPrecision,
     semanticMerging: undefined === options.semanticMerging ? false : !!options.semanticMerging,
     shorthandCompacting: undefined === options.shorthandCompacting ? true : !!options.shorthandCompacting,
     sourceMap: options.sourceMap,

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -55,7 +55,7 @@ var CleanCSS = module.exports = function CleanCSS(options) {
     relativeTo: options.relativeTo,
     restructuring: undefined === options.restructuring ? true : !!options.restructuring,
     root: options.root || process.cwd(),
-    roundingPrecision: options.roundingPrecision,
+    roundingPrecision: undefined === options.roundingPrecision ? undefined : parseInt(options.roundingPrecision),
     semanticMerging: undefined === options.semanticMerging ? false : !!options.semanticMerging,
     shorthandCompacting: undefined === options.shorthandCompacting ? true : !!options.shorthandCompacting,
     sourceMap: options.sourceMap,

--- a/lib/selectors/simple.js
+++ b/lib/selectors/simple.js
@@ -86,7 +86,7 @@ function whitespaceMinifier(name, value) {
 }
 
 function precisionMinifier(_, value, precisionOptions) {
-  if (precisionOptions.value === -1 || value.indexOf('.') === -1)
+  if (precisionOptions.value === -1 || isNaN(precisionOptions.value) || value.indexOf('.') === -1)
     return value;
 
   return value
@@ -394,6 +394,10 @@ function buildPrecision(options) {
   precision.value = options.roundingPrecision === undefined ?
     DEFAULT_ROUNDING_PRECISION :
     parseInt(options.roundingPrecision);
+
+  if (isNaN(precision.value))
+    return precision;
+
   precision.multiplier = Math.pow(10, precision.value);
   precision.regexp = new RegExp('(\\d*\\.\\d{' + (precision.value + 1) + ',})px', 'g');
 

--- a/lib/selectors/simple.js
+++ b/lib/selectors/simple.js
@@ -393,7 +393,7 @@ function buildPrecision(options) {
 
   precision.value = options.roundingPrecision === undefined ?
     DEFAULT_ROUNDING_PRECISION :
-    options.roundingPrecision;
+    parseInt(options.roundingPrecision);
   precision.multiplier = Math.pow(10, precision.value);
   precision.regexp = new RegExp('(\\d*\\.\\d{' + (precision.value + 1) + ',})px', 'g');
 

--- a/test/selectors/simple-test.js
+++ b/test/selectors/simple-test.js
@@ -501,6 +501,22 @@ vows.describe('simple optimizations')
     }, { roundingPrecision: -1 })
   )
   .addBatch(
+    propertyContext('rounding disabled when option value not castable to int', {
+      'pixels': [
+        'a{transform:translateY(123.31135px)}',
+        [['transform', 'translateY(123.31135px)']]
+      ],
+      'percents': [
+        'a{left:20.1231%}',
+        [['left', '20.1231%']]
+      ],
+      'ems': [
+        'a{left:1.1231em}',
+        [['left', '1.1231em']]
+      ]
+    }, { roundingPrecision: '\'-1\'' })
+  )
+  .addBatch(
     propertyContext('units', {
       'pixels': [
         'a{width:0px}',


### PR DESCRIPTION
Follow-up to #817. Doesn't fix the main issue (rounding-precision "-1" value in CLI), though improving a bit the situation.
- Cast value in the options object, as it's done for the other options.
  - edit: Rather cast in the `buildPrecision()` function as it appears to be simpler.
- Avoid instructions if NaN, rather than be working by luck.
