### PR TITLE
Re-enables batch tests on Windows.

### DIFF
--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -7,14 +7,11 @@ var vows = require('vows');
 
 var lineBreak = require('os').EOL;
 
-if (process.platform == 'win32') {
-  return;
-}
-
 function assertEqualLineByLine(expected, actual) {
   var expectedLines = expected.split(lineBreak);
   var actualLines = actual.split(lineBreak);
 
+  assert.equal(expectedLines.length, actualLines.length);
   expectedLines.forEach(function (line, i) {
     assert.equal(line, actualLines[i]);
   });


### PR DESCRIPTION
`assertEqualLineByLine()` did not check if `expected` has the same number of lines as `actual`, which in turn cause `vow` to hang in some 100% CPU loop on Windows.