### PR TITLE
Fix wrong require arity

### DIFF
--- a/lib/optimizer/level-2/properties/override-properties.js
+++ b/lib/optimizer/level-2/properties/override-properties.js
@@ -11,7 +11,7 @@ var deepClone = require('../clone').deep;
 var restoreWithComponents = require('../restore-with-components');
 var shallowClone = require('../clone').shallow;
 
-var restoreFromOptimizing = require('../../restore-from-optimizing', restoreWithComponents);
+var restoreFromOptimizing = require('../../restore-from-optimizing');
 
 var Token = require('../../../tokenizer/token');
 var Marker = require('../../../tokenizer/marker');


### PR DESCRIPTION
`require` accepts a single operand.

That's crashing when bundling the source code with Webpack.