### PR TITLE
Add process method (compatibility with optimize-css-assets-webpack-plugin)

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -49,10 +49,10 @@ var CleanCSS = module.exports = function CleanCSS(options) {
 
 // for compatibility with optimize-css-assets-webpack-plugin
 CleanCSS.process = function (input, opts) {
-  var opts_to = opts.to;
+  var optsTo = opts.to;
   delete opts.to;
 
-  var cleanCss = new CleanCSS(Object.assign({ returnPromise: true, rebaseTo: opts_to }, opts));
+  var cleanCss = new CleanCSS(Object.assign({ returnPromise: true, rebaseTo: optsTo }, opts));
   return cleanCss.minify(input)
          .then(function(output) {
            return { css: output.styles };

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -47,7 +47,7 @@ var CleanCSS = module.exports = function CleanCSS(options) {
 };
 
 
-// for compatibility with optimize-css-assets-webpack-plugin
+// for compatibility with optimize-css-assets-webpack-plugin (cssnano `process(...)`)
 CleanCSS.process = function (input, opts) {
   var cleanCss = new CleanCSS(Object.assign({ returnPromise: true }, opts));
   return cleanCss.minify(input)

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -47,13 +47,16 @@ var CleanCSS = module.exports = function CleanCSS(options) {
 };
 
 
-// for compatibility with optimize-css-assets-webpack-plugin (cssnano `process(...)`)
+// for compatibility with optimize-css-assets-webpack-plugin
 CleanCSS.process = function (input, opts) {
-  var cleanCss = new CleanCSS(Object.assign({ returnPromise: true }, opts));
+  var opts_to = opts.to;
+  delete opts.to;
+
+  var cleanCss = new CleanCSS(Object.assign({ returnPromise: true, rebaseTo: opts_to }, opts));
   return cleanCss.minify(input)
-  .then(function(output) {
-    return { css: output.styles };
-  });
+         .then(function(output) {
+           return { css: output.styles };
+         });
 };
 
 

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -49,11 +49,11 @@ var CleanCSS = module.exports = function CleanCSS(options) {
 
 // for compatibility with optimize-css-assets-webpack-plugin
 CleanCSS.process = function (input, opts) {
-  return new Promise(function (resolve) {
-    var cleanCss = new CleanCSS(opts);
-    var output   = cleanCss.minify(input);
-    resolve({ css: output.styles });
-  });
+  var cleanCss = new CleanCSS(Object.assign({ returnPromise: true }, opts));
+  return cleanCss.minify(input)
+         .then(function(output) {
+           return { css: output.styles };
+         });
 };
 
 

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -54,9 +54,9 @@ CleanCSS.process = function (input, opts) {
 
   var cleanCss = new CleanCSS(Object.assign({ returnPromise: true, rebaseTo: optsTo }, opts));
   return cleanCss.minify(input)
-         .then(function(output) {
-           return { css: output.styles };
-         });
+  .then(function(output) {
+    return { css: output.styles };
+  });
 };
 
 

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -46,6 +46,17 @@ var CleanCSS = module.exports = function CleanCSS(options) {
   };
 };
 
+
+// for compatibility with optimize-css-assets-webpack-plugin
+CleanCSS.process = function (input, opts) {
+  return new Promise(function (resolve, reject) {
+    var cleanCss = new CleanCSS(opts);
+    var output   = cleanCss.minify(input);
+    resolve({ css: output.styles });
+  });
+};
+
+
 CleanCSS.prototype.minify = function (input, maybeSourceMap, maybeCallback) {
   var options = this.options;
 

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -51,9 +51,9 @@ var CleanCSS = module.exports = function CleanCSS(options) {
 CleanCSS.process = function (input, opts) {
   var cleanCss = new CleanCSS(Object.assign({ returnPromise: true }, opts));
   return cleanCss.minify(input)
-         .then(function(output) {
-           return { css: output.styles };
-         });
+  .then(function(output) {
+    return { css: output.styles };
+  });
 };
 
 

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -49,7 +49,7 @@ var CleanCSS = module.exports = function CleanCSS(options) {
 
 // for compatibility with optimize-css-assets-webpack-plugin
 CleanCSS.process = function (input, opts) {
-  return new Promise(function (resolve, reject) {
+  return new Promise(function (resolve) {
     var cleanCss = new CleanCSS(opts);
     var output   = cleanCss.minify(input);
     resolve({ css: output.styles });


### PR DESCRIPTION
This PR adds the process method to clean-css so 
[optimize-css-assets-webpack-plugin](https://github.com/NMFR/optimize-css-assets-webpack-plugin) can use it as css processor.

Closes issue https://github.com/jakubpawlowicz/clean-css/issues/943.