### PR TITLE
Fix "special comments" option on web interface

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -103,8 +103,8 @@
               </select>
             </li>
             <li class="fine-grained-options__option">
-              <select class="settings__option settings__option--select js-settings-option" id="level_1_keep_special_comments" name="level[1][keepSpecialComments]">
-                <option value="*" selected>Special comments: keep all</option>
+              <select class="settings__option settings__option--select js-settings-option" id="level_1_special_comments" name="level[1][specialComments]">
+                <option value="all" selected>Special comments: keep all</option>
                 <option value="1">Special comments: remove all but the first one</option>
                 <option value="0">Special comments: remove all</option>
               </select>


### PR DESCRIPTION
While debugging https://github.com/jakubpawlowicz/clean-css/issues/955, I was confused why the special comments option on the web interface wasn't working, while the CLI works fine.

Reason is because the option in the HTML is `keepSpecialComments`, it should be `specialComments` instead.
Also changed `*` to `all` as per https://github.com/jakubpawlowicz/clean-css/blob/bbc77a9d8b12fbce85424df322c247472e23ad2e/lib/optimizer/level-1/optimize.js#L521