### PR TITLE
Reenable ieSuffixHack, because it affects IE10+

### DIFF
--- a/lib/options/compatibility.js
+++ b/lib/options/compatibility.js
@@ -11,7 +11,7 @@ var DEFAULTS = {
       ieBangHack: false, // !ie suffix hacks on IE<8
       ieFilters: false, // whether to preserve `filter` and `-ms-filter` properties
       iePrefixHack: false, // underscore / asterisk prefix hacks on IE
-      ieSuffixHack: false, // \9 suffix hacks on IE6-9
+      ieSuffixHack: true, // \9 suffix hacks on IE6-9, \0 suffix hack on IE6-11
       merging: true, // merging properties into one
       shorterLengthUnits: false, // optimize pixel units into `pt`, `pc` or `in` units
       spaceAfterClosingBrace: true, // 'url() no-repeat' to 'url()no-repeat'
@@ -82,7 +82,6 @@ DEFAULTS.ie10 = DEFAULTS['*'];
 DEFAULTS.ie9 = merge(DEFAULTS['*'], {
   properties: {
     ieFilters: true,
-    ieSuffixHack: true
   }
 });
 


### PR DESCRIPTION
I presume this was disabled as the \9 suffix hack no longer works in IE 11.
(I’m unclear about whether it worked in IE 10 or not, though one source I found
suggests it does; I lack the inclination to confirm it.)

I have evidence of a variant that *does* work in IE 11
(I personally verified it just now):

    \0

Or, if you feel particularly exuberant:

    \0/

My brief research suggests that you could put any printable character after the
backslash and they would all be equivalent to \9, with the exception of \0
which is different somehow.

Anyway, as I have proof of a suffix hack working in IE 11, this needs to be
enabled once again.

(Side note: in clean-css 3.4 it would rewrite \0 to \9, which broke things that
deliberately used \0 to target all IE. Fortunately this is no longer the case.)