### PR TITLE
Promote installing as dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ clean-css requires Node.js 4.0+ (tested on Linux, OS X, and Windows)
 # Install
 
 ```
-npm install clean-css
+npm install --save-dev clean-css
 ```
 
 # Use


### PR DESCRIPTION
clean-css is a typical dev dependency which should be installed as such
in most of the cases. By providing an example code snippet with the
`--save-dev` option, we're helping the users to do the right thing.