### PR TITLE
Add an option for keeping trailing semicolons in rule

### DIFF
--- a/lib/options/format.js
+++ b/lib/options/format.js
@@ -28,7 +28,8 @@ var DEFAULTS = {
   indentBy: 0,
   indentWith: IndentWith.Space,
   spaces: spaces(false),
-  wrapAt: false
+  wrapAt: false,
+  addSemicolonAfterLastPropertyInPropertyBlock: false
 };
 
 var BEAUTIFY_ALIAS = 'beautify';

--- a/lib/options/format.js
+++ b/lib/options/format.js
@@ -29,7 +29,7 @@ var DEFAULTS = {
   indentWith: IndentWith.Space,
   spaces: spaces(false),
   wrapAt: false,
-  addSemicolonAfterLastPropertyInPropertyBlock: false
+  semicolonAfterLastProperty: false
 };
 
 var BEAUTIFY_ALIAS = 'beautify';

--- a/lib/writer/helpers.js
+++ b/lib/writer/helpers.js
@@ -79,7 +79,20 @@ function property(context, tokens, position, lastPropertyAt) {
   var store = context.store;
   var token = tokens[position];
   var isPropertyBlock = token[2][0] == Token.PROPERTY_BLOCK;
-  var needsSemicolon = position < lastPropertyAt || isPropertyBlock;
+
+  var needsSemicolon;
+  if( context.format ) {
+    if( context.format.addSemicolonAfterLastPropertyInPropertyBlock || isPropertyBlock ) {
+      needsSemicolon = true;
+    } else if( position < lastPropertyAt ) {
+      needsSemicolon = true;
+    } else {
+      needsSemicolon = false;
+    }
+  } else {
+    needsSemicolon = position < lastPropertyAt || isPropertyBlock
+  }
+
   var isLast = position === lastPropertyAt;
 
   switch (token[0]) {

--- a/lib/writer/helpers.js
+++ b/lib/writer/helpers.js
@@ -81,16 +81,16 @@ function property(context, tokens, position, lastPropertyAt) {
   var isPropertyBlock = token[2][0] == Token.PROPERTY_BLOCK;
 
   var needsSemicolon;
-  if( context.format ) {
-    if( context.format.addSemicolonAfterLastPropertyInPropertyBlock || isPropertyBlock ) {
+  if ( context.format ) {
+    if ( context.format.semicolonAfterLastProperty || isPropertyBlock ) {
       needsSemicolon = true;
-    } else if( position < lastPropertyAt ) {
+    } else if ( position < lastPropertyAt ) {
       needsSemicolon = true;
     } else {
       needsSemicolon = false;
     }
   } else {
-    needsSemicolon = position < lastPropertyAt || isPropertyBlock
+    needsSemicolon = position < lastPropertyAt || isPropertyBlock;
   }
 
   var isLast = position === lastPropertyAt;

--- a/test/module-test.js
+++ b/test/module-test.js
@@ -861,7 +861,7 @@ vows.describe('module tests').addBatch({
   },
   'keeps trailing semicolons if option is set': {
     'topic': function() {
-      return new CleanCSS({format: { addSemicolonAfterLastPropertyInPropertyBlock: true }}).minify('*{ font-size:12px; color:#ea7500; }');
+      return new CleanCSS({format: { semicolonAfterLastProperty: true }}).minify('*{ font-size:12px; color:#ea7500; }');
     },
     'should minify correctly': function (error, minified) {
       assert.equal(minified.styles, '*{font-size:12px;color:#ea7500;}');

--- a/test/module-test.js
+++ b/test/module-test.js
@@ -858,5 +858,16 @@ vows.describe('module tests').addBatch({
     'should give right output': function (minified) {
       assert.equal(minified.styles, '.one{color:red}.three{background-image:url(test/fixtures/partials/extra/down.gif)}');
     }
+  },
+  'keeps trailing semicolons if option is set': {
+    'topic': function() {
+      return new CleanCSS({format: { addSemicolonAfterLastPropertyInPropertyBlock: true }}).minify('*{ font-size:12px; color:#ea7500; }');
+    },
+    'should minify correctly': function (error, minified) {
+      assert.equal(minified.styles, '*{font-size:12px;color:#ea7500;}');
+    },
+    'should raise no errors': function (error, minified) {
+      assert.isEmpty(minified.errors);
+    }
   }
 }).export(module);

--- a/test/options/format-test.js
+++ b/test/options/format-test.js
@@ -47,7 +47,7 @@ vows.describe(formatFrom)
             beforeValue: false
           },
           wrapAt: false,
-          addSemicolonAfterLastPropertyInPropertyBlock: false
+          semicolonAfterLastProperty: false
         });
       }
     },
@@ -76,7 +76,7 @@ vows.describe(formatFrom)
             beforeValue: false
           },
           wrapAt: false,
-          addSemicolonAfterLastPropertyInPropertyBlock: false
+          semicolonAfterLastProperty: false
         });
       }
     },
@@ -105,7 +105,7 @@ vows.describe(formatFrom)
             beforeValue: false
           },
           wrapAt: false,
-          addSemicolonAfterLastPropertyInPropertyBlock: false
+          semicolonAfterLastProperty: false
         });
       }
     },
@@ -134,7 +134,7 @@ vows.describe(formatFrom)
             beforeValue: false
           },
           wrapAt: false,
-          addSemicolonAfterLastPropertyInPropertyBlock: false
+          semicolonAfterLastProperty: false
         });
       }
     },
@@ -163,7 +163,7 @@ vows.describe(formatFrom)
             beforeValue: false
           },
           wrapAt: false,
-          addSemicolonAfterLastPropertyInPropertyBlock: false
+          semicolonAfterLastProperty: false
         });
       }
     },
@@ -192,7 +192,7 @@ vows.describe(formatFrom)
             beforeValue: false
           },
           wrapAt: 25,
-          addSemicolonAfterLastPropertyInPropertyBlock: false
+          semicolonAfterLastProperty: false
         });
       }
     },
@@ -221,7 +221,7 @@ vows.describe(formatFrom)
             beforeValue: false
           },
           wrapAt: false,
-          addSemicolonAfterLastPropertyInPropertyBlock: false
+          semicolonAfterLastProperty: false
         });
       }
     },
@@ -250,7 +250,7 @@ vows.describe(formatFrom)
             beforeValue: true
           },
           wrapAt: false,
-          addSemicolonAfterLastPropertyInPropertyBlock: false
+          semicolonAfterLastProperty: false
         });
       }
     },
@@ -279,7 +279,7 @@ vows.describe(formatFrom)
             beforeValue: false
           },
           wrapAt: false,
-          addSemicolonAfterLastPropertyInPropertyBlock: false
+          semicolonAfterLastProperty: false
         });
       }
     }

--- a/test/options/format-test.js
+++ b/test/options/format-test.js
@@ -46,7 +46,8 @@ vows.describe(formatFrom)
             beforeBlockBegins: false,
             beforeValue: false
           },
-          wrapAt: false
+          wrapAt: false,
+          addSemicolonAfterLastPropertyInPropertyBlock: false
         });
       }
     },
@@ -74,7 +75,8 @@ vows.describe(formatFrom)
             beforeBlockBegins: false,
             beforeValue: false
           },
-          wrapAt: false
+          wrapAt: false,
+          addSemicolonAfterLastPropertyInPropertyBlock: false
         });
       }
     },
@@ -102,7 +104,8 @@ vows.describe(formatFrom)
             beforeBlockBegins: false,
             beforeValue: false
           },
-          wrapAt: false
+          wrapAt: false,
+          addSemicolonAfterLastPropertyInPropertyBlock: false
         });
       }
     },
@@ -130,7 +133,8 @@ vows.describe(formatFrom)
             beforeBlockBegins: false,
             beforeValue: false
           },
-          wrapAt: false
+          wrapAt: false,
+          addSemicolonAfterLastPropertyInPropertyBlock: false
         });
       }
     },
@@ -158,7 +162,8 @@ vows.describe(formatFrom)
             beforeBlockBegins: false,
             beforeValue: false
           },
-          wrapAt: false
+          wrapAt: false,
+          addSemicolonAfterLastPropertyInPropertyBlock: false
         });
       }
     },
@@ -186,7 +191,8 @@ vows.describe(formatFrom)
             beforeBlockBegins: false,
             beforeValue: false
           },
-          wrapAt: 25
+          wrapAt: 25,
+          addSemicolonAfterLastPropertyInPropertyBlock: false
         });
       }
     },
@@ -214,7 +220,8 @@ vows.describe(formatFrom)
             beforeBlockBegins: false,
             beforeValue: false
           },
-          wrapAt: false
+          wrapAt: false,
+          addSemicolonAfterLastPropertyInPropertyBlock: false
         });
       }
     },
@@ -242,7 +249,8 @@ vows.describe(formatFrom)
             beforeBlockBegins: true,
             beforeValue: true
           },
-          wrapAt: false
+          wrapAt: false,
+          addSemicolonAfterLastPropertyInPropertyBlock: false
         });
       }
     },
@@ -270,7 +278,8 @@ vows.describe(formatFrom)
             beforeBlockBegins: false,
             beforeValue: false
           },
-          wrapAt: false
+          wrapAt: false,
+          addSemicolonAfterLastPropertyInPropertyBlock: false
         });
       }
     }


### PR DESCRIPTION
See https://github.com/jakubpawlowicz/clean-css/issues/980.

I'm not certain I have implemented this in the way you wanted me too, so feel free to offer improvements

Thanks in advance