### PR TITLE
Changes to is-allowed-resource.js 

### DIFF
--- a/lib/reader/is-allowed-resource.js
+++ b/lib/reader/is-allowed-resource.js
@@ -1,31 +1,14 @@
-var path = require('path');
-var url = require('url');
-
-var isRemoteResource = require('../utils/is-remote-resource');
 var hasProtocol = require('../utils/has-protocol');
 
 var HTTP_PROTOCOL = 'http:';
 
 function isAllowedResource(uri, isRemote, rules) {
-  var match;
-  var absoluteUri;
   var normalizedRule;
-
-  if (rules.length === 0) {
-    return false;
-  }
+  var x;
 
   if (isRemote && !hasProtocol(uri)) {
     uri = HTTP_PROTOCOL + uri;
   }
-
-  match = isRemote ?
-    url.parse(uri).host :
-    uri;
-
-  absoluteUri = isRemote ?
-    uri :
-    path.resolve(uri);
 
     /***
      1) whitelist  uri === rule
@@ -54,8 +37,7 @@ function isAllowedResource(uri, isRemote, rules) {
      * MATCHING PATH TO URI
      */
 
-  for(var x = 0; x< rules.length; ++x){
-
+  for(x = 0; x< rules.length; ++x){
       if(rules[x][0] == "!"){
           normalizedRule = rules[x].substring(1);
           if(uri.indexOf(normalizedRule)!= -1){
@@ -88,10 +70,6 @@ function isAllowedResource(uri, isRemote, rules) {
      * OTHERWISE RETURN FALSE;
      */
   return false;
-}
-
-function isRemoteRule(rule) {
-  return isRemoteResource(rule) || url.parse(HTTP_PROTOCOL + '//' + rule).host == rule;
 }
 
 module.exports = isAllowedResource;

--- a/lib/reader/is-allowed-resource.js
+++ b/lib/reader/is-allowed-resource.js
@@ -9,11 +9,7 @@ var HTTP_PROTOCOL = 'http:';
 function isAllowedResource(uri, isRemote, rules) {
   var match;
   var absoluteUri;
-  var allowed = isRemote ? false : true;
-  var rule;
-  var isNegated;
   var normalizedRule;
-  var i;
 
   if (rules.length === 0) {
     return false;
@@ -31,43 +27,67 @@ function isAllowedResource(uri, isRemote, rules) {
     uri :
     path.resolve(uri);
 
-  for (i = 0; i < rules.length; i++) {
-    rule = rules[i];
-    isNegated = rule[0] == '!';
-    normalizedRule = rule.substring(1);
+    /***
+     1) whitelist  uri === rule
+     2) blacklist  "!"+uri === rule
+     3) match partial paths
+     4) match partial negated paths
+     3)  is the resource local?
+       a) yes --  whitelist "local" === rule
+       b) no
+     4) whitelist uri.hostname === rule
+     5) blacklist uri.hostname === !rule
+     6) whitelist "remote" === rule
+     ***/
 
-    if (isNegated && isRemote && isRemoteRule(normalizedRule)) {
-      allowed = allowed && !isAllowedResource(uri, true, [normalizedRule]);
-    } else if (isNegated && !isRemote && !isRemoteRule(normalizedRule)) {
-      allowed = allowed && !isAllowedResource(uri, false, [normalizedRule]);
-    } else if (isNegated) {
-      allowed = allowed && true;
-    } else if (rule == 'all') {
-      allowed = true;
-    } else if (isRemote && rule == 'local') {
-      allowed = allowed || false;
-    } else if (isRemote && rule == 'remote') {
-      allowed = true;
-    } else if (!isRemote && rule == 'remote') {
-      allowed = false;
-    } else if (!isRemote && rule == 'local') {
-      allowed = true;
-    } else if (rule === match) {
-      allowed = true;
-    } else if (rule === uri) {
-      allowed = true;
-    } else if (isRemote && absoluteUri.indexOf(rule) === 0) {
-      allowed = true;
-    } else if (!isRemote && absoluteUri.indexOf(path.resolve(rule)) === 0) {
-      allowed = true;
-    } else if (isRemote != isRemoteRule(normalizedRule)) {
-      allowed = allowed && true;
-    } else {
-      allowed = false;
-    }
+
+    /**
+     * MATCHING EXACT RULE TO URI
+     */
+  if(rules.indexOf(uri)!== -1){
+    return true;
+  } else if (rules.indexOf("!" + uri) !== -1) {
+      return false;
   }
 
-  return allowed;
+    /**
+     * MATCHING PATH TO URI
+     */
+
+  for(var x = 0; x< rules.length; ++x){
+
+      if(rules[x][0] == "!"){
+          normalizedRule = rules[x].substring(1);
+          if(uri.indexOf(normalizedRule)!= -1){
+              return false;
+          }
+      } else {
+          if(uri.indexOf(rules[x])!= -1){
+              return true;
+          }
+      }
+  }
+
+    /**
+     * CHECK THAT GENERIC RULE TYPE LOCAL / REMOTE IS ALLOWED
+     */
+  if(isRemote && rules.indexOf("remote")  !== -1){
+    return true;
+  } else if (!isRemote && rules.indexOf("local") !== -1){
+    return true;
+  } else if(rules.indexOf("all") !== -1){
+    return true;
+  } else if (rules.indexOf("none") !== -1){
+    return false;
+  } else if (rules.indexOf("!remote") && isRemote){
+    return false;
+  } else if (rules.indexOf("!local") && !isRemote){
+    return false;
+  }
+    /***
+     * OTHERWISE RETURN FALSE;
+     */
+  return false;
 }
 
 function isRemoteRule(rule) {

--- a/test/reader/is-allowed-resource-test.js
+++ b/test/reader/is-allowed-resource-test.js
@@ -113,10 +113,16 @@ vows.describe(isAllowedResource)
             assert.isFalse(isAllowedResource(topic, true, ['remote', '!http://example.com']));
         }
     },
-    'blacklisted domain3':{
+    'blacklisted a different domain':{
         'topic':'http://example.com/path/to/styles.css',
-        'is not allowed': function (topic) {
+        'is allowed': function (topic) {
             assert.isTrue(isAllowedResource(topic, true, ['remote', '!http://example2.com']));
+        }
+    },
+    'blacklisted php file':{
+        'topic':'http://example.com/path/to/styles.php',
+        'is not allowed': function (topic) {
+            assert.isFalse(isAllowedResource(topic, true, ['remote', 'local', '!.php']));
         }
     }
 }).export(module);

--- a/test/reader/is-allowed-resource-test.js
+++ b/test/reader/is-allowed-resource-test.js
@@ -76,5 +76,47 @@ vows.describe(isAllowedResource)
         assert.isFalse(isAllowedResource(topic, true, ['!127.0.0.1', '!assets.127.0.0.1', '!path/to/styles.css']));
       }
     }
-  })
-  .export(module);
+  }).addBatch({
+    'local and !file without path':{
+        'topic':'style.css',
+        'is not allowed': function (topic) {
+            assert.isFalse(isAllowedResource(topic, false, ['local', '!style.css']));
+        }
+    },
+    'local and !file including path':{
+      'topic':'../path/to/style.css',
+      'is not allowed': function (topic) {
+            assert.isFalse(isAllowedResource(topic, false, ['!style.css', 'local']));
+        }
+    },
+    'remote and !file':{
+        'topic':'http://example.com/path/to/styles.css',
+        'is not allowed': function (topic) {
+            assert.isFalse(isAllowedResource(topic, true, ['remote', 'local', '!http://example.com/path/to/styles.css']));
+        }
+    },
+    'remote and !file v2':{
+        'topic':'http://example.com/path/to/styles2.css',
+        'is not allowed': function (topic) {
+            assert.isTrue(isAllowedResource(topic, true, ['remote', 'local', '!http://example.com/path/to/styles.css']));
+        }
+    },
+    'blacklisted domain':{
+        'topic':'http://example.com/path/to/styles.css',
+            'is not allowed': function (topic) {
+            assert.isFalse(isAllowedResource(topic, true, ['remote', '!example.com']));
+        }
+    },
+    'blacklisted domain with protocol':{
+        'topic':'http://example.com/path/to/styles.css',
+        'is not allowed': function (topic) {
+            assert.isFalse(isAllowedResource(topic, true, ['remote', '!http://example.com']));
+        }
+    },
+    'blacklisted domain3':{
+        'topic':'http://example.com/path/to/styles.css',
+        'is not allowed': function (topic) {
+            assert.isTrue(isAllowedResource(topic, true, ['remote', '!http://example2.com']));
+        }
+    }
+}).export(module);


### PR DESCRIPTION
Benefits:  Allows for very targeted whitelisting/blacklisting
Downside:  The path matcher is pretty loose--it could be the case that by whitelisting something generic you could be allowing certain remote resources..

i.e. ["style.css", "!example.com"] ==> would inline "www.example.com/style.css"
["!example.com", "style.css"] ==>  would not inline "www.example.com/style.css"

For partially matching paths they are checked in order that they occur. 