### PR TITLE
Fix: Prevent error if property block has no value (level 0)

### DIFF
--- a/lib/writer/helpers.js
+++ b/lib/writer/helpers.js
@@ -77,7 +77,9 @@ function lastPropertyIndex(tokens) {
 function property(context, tokens, position, lastPropertyAt) {
   var store = context.store;
   var token = tokens[position];
-  var isPropertyBlock = token[2][0] == Token.PROPERTY_BLOCK;
+
+  var propertyValue = token[2];
+  var isPropertyBlock = propertyValue && propertyValue[0] === Token.PROPERTY_BLOCK;
 
   var needsSemicolon;
   if ( context.format ) {
@@ -111,7 +113,9 @@ function property(context, tokens, position, lastPropertyAt) {
     case Token.PROPERTY:
       store(context, token[1]);
       store(context, colon(context));
-      value(context, token);
+      if (propertyValue) {
+        value(context, token);
+      }
       store(context, needsSemicolon ? semicolon(context, Breaks.AfterProperty, isLast) : emptyCharacter);
       break;
     case Token.RAW:

--- a/test/optimizer/level-0/optimizations-test.js
+++ b/test/optimizer/level-0/optimizations-test.js
@@ -11,4 +11,12 @@ vows.describe('level 0')
       ]
     }, { level: 0 })
   )
+  .addBatch(
+    optimizerContext('empty properties', {
+      'are written': [
+        'a{color:#f00;font-weight:;background:red}',
+        'a{color:#f00;font-weight:;background:red}'
+      ]
+    }, { level: 0 })
+  )
   .export(module);


### PR DESCRIPTION
The tokenizer will parse a property like `width: ;`, but the property helper for level 0 was not accounting for properties without a value and would throw a `TypeError` if the value was missing.

For example, the following would throw an unhandled error:

```js
const CleanCSS = require('clean-css')
const cleanCss = new CleanCSS({ level: 0 })

cleanCss.minify('a{color:#f00;font-weight:;background:red}')
// TypeError: Cannot read property '0' of undefined
//   at property (./clean-css/lib/writer/helpers.js:80:33)
```

With this change, the property helper now checks for a missing property value before trying to access it.