### PR TITLE
feat(unit): support rpx #1073 

### DIFF
--- a/lib/optimizer/validator.js
+++ b/lib/optimizer/validator.js
@@ -342,7 +342,8 @@ var Units = [
   'vm',
   'vmax',
   'vmin',
-  'vw'
+  'vw',
+  'rpx'
 ];
 
 function isColor(value) {


### PR DESCRIPTION
Actually，there are many dev frameworks or platforms are support the `rpx`:

* Wechat miniprogram css style: https://developers.weixin.qq.com/miniprogram/en/dev/framework/view/wxss.html#unit-of-measurement
* [Alipay Miniapp](https://global.alipay.com/doc/tool/miniapp) style: https://docs.alipay.com/mini/framework/acss#rpx
* TouTiao microapp css: https://developer.toutiao.com/docs/framework/ttss.html#%E5%B0%BA%E5%AF%B8%E5%8D%95%E4%BD%8D
* Baidu SmartApp css: https://smartprogram.baidu.com/docs/develop/framework/view_css
* wepy : https://github.com/Tencent/wepy
* mpvue: https://github.com/Meituan-Dianping/mpvue
...