### PR TITLE
Fix local fonts with colors in name

### DIFF
--- a/lib/optimizer/level-1/optimize.js
+++ b/lib/optimizer/level-1/optimize.js
@@ -37,7 +37,12 @@ var IMPORT_PREFIX_PATTERN = /^@import/i;
 var QUOTED_PATTERN = /^('.*'|".*")$/;
 var QUOTED_BUT_SAFE_PATTERN = /^['"][a-zA-Z][a-zA-Z\d\-_]+['"]$/;
 var URL_PREFIX_PATTERN = /^url\(/i;
+var LOCAL_PREFIX_PATTERN = /^local\(/i;
 var VARIABLE_NAME_PATTERN = /^--\S+$/;
+
+function isLocal(value){
+  return LOCAL_PREFIX_PATTERN.test(value);
+}
 
 function isNegative(value) {
   return value && value[1][0] == '-' && parseFloat(value[1]) < 0;
@@ -443,7 +448,7 @@ function optimizeBody(rule, properties, context) {
         value = !options.compatibility.properties.urlQuotes ?
           removeUrlQuotes(value) :
           value;
-      } else if (isQuoted(value)) {
+      } else if (isQuoted(value) || isLocal(value)) {
         value = levelOptions.removeQuotes ?
           removeQuotes(name, value) :
           value;

--- a/test/optimizer/level-1/optimize-test.js
+++ b/test/optimizer/level-1/optimize-test.js
@@ -540,6 +540,10 @@ vows.describe('level 1 optimizations')
       'with mixed bold weight and variant #2': [
         'a{font:bold normal 17px sans-serif}',
         'a{font:bold normal 17px sans-serif}'
+      ],
+      'with color in local font name': [
+        '@font-face{src:local("Sans Black Italic")}',
+        '@font-face{src:local("Sans Black Italic")}',
       ]
     }, { level: 1 })
   )


### PR DESCRIPTION
This MR fixes #1058. 

This:
```
@font-face {
  src: local("Some Sans Black Italic");
}
```
became`@font-face{src:local("Some Sans #000 Italic");}`  
instead of `@font-face{src:local("Some Sans Black Italic");}`

Comments / Suggestions welcome :smile: 