### PR TITLE
Prevent unquoting on grid elements

### DIFF
--- a/lib/optimizer/level-1/optimize.js
+++ b/lib/optimizer/level-1/optimize.js
@@ -336,7 +336,7 @@ function optimizeZeroUnits(name, value) {
 }
 
 function removeQuotes(name, value) {
-  if (name == 'content' || name.indexOf('font-variation-settings') > -1 || name.indexOf('font-feature-settings') > -1 || name.indexOf('grid-') > -1) {
+  if (name == 'content' || name.indexOf('font-variation-settings') > -1 || name.indexOf('font-feature-settings') > -1 || name == "grid" || name.indexOf('grid-') > -1) {
     return value;
   }
 

--- a/lib/optimizer/level-1/optimize.js
+++ b/lib/optimizer/level-1/optimize.js
@@ -336,7 +336,7 @@ function optimizeZeroUnits(name, value) {
 }
 
 function removeQuotes(name, value) {
-  if (name == 'content' || name.indexOf('font-variation-settings') > -1 || name.indexOf('font-feature-settings') > -1 || name == "grid" || name.indexOf('grid-') > -1) {
+  if (name == 'content' || name.indexOf('font-variation-settings') > -1 || name.indexOf('font-feature-settings') > -1 || name == 'grid' || name.indexOf('grid-') > -1) {
     return value;
   }
 

--- a/test/optimizer/level-1/optimize-test.js
+++ b/test/optimizer/level-1/optimize-test.js
@@ -1225,6 +1225,10 @@ vows.describe('level 1 optimizations')
         '.block{-webkit-font-feature-settings:"scmp","swsh" 2}',
         '.block{-webkit-font-feature-settings:"scmp","swsh" 2}'
       ],
+      'grid': [
+        '.block{grid:"header" 20% "nav" auto/auto}',
+        '.block{grid:"header" 20% "nav" auto/auto}'
+      ],
       'grid-template': [
         '.block{grid-template:"header" 20% "nav" auto}',
         '.block{grid-template:"header" 20% "nav" auto}'


### PR DESCRIPTION
Add "grid" element to list of elements ignored by removeQuotes.
This prevents required quotes from being removed from single column grids.

Fixes #1078 