### PR TITLE
Allow user to define, which properties should be kept

### DIFF
--- a/lib/optimizer/level-1/optimize.js
+++ b/lib/optimizer/level-1/optimize.js
@@ -37,7 +37,7 @@ var IMPORT_PREFIX_PATTERN = /^@import/i;
 var QUOTED_PATTERN = /^('.*'|".*")$/;
 var QUOTED_BUT_SAFE_PATTERN = /^['"][a-zA-Z][a-zA-Z\d\-_]+['"]$/;
 var URL_PREFIX_PATTERN = /^url\(/i;
-  var LOCAL_PREFIX_PATTERN = /^local\(/i;
+var LOCAL_PREFIX_PATTERN = /^local\(/i;
 var VARIABLE_NAME_PATTERN = /^--\S+$/;
 
 function isLocal(value){

--- a/lib/optimizer/level-1/optimize.js
+++ b/lib/optimizer/level-1/optimize.js
@@ -37,7 +37,7 @@ var IMPORT_PREFIX_PATTERN = /^@import/i;
 var QUOTED_PATTERN = /^('.*'|".*")$/;
 var QUOTED_BUT_SAFE_PATTERN = /^['"][a-zA-Z][a-zA-Z\d\-_]+['"]$/;
 var URL_PREFIX_PATTERN = /^url\(/i;
-var LOCAL_PREFIX_PATTERN = /^local\(/i;
+  var LOCAL_PREFIX_PATTERN = /^local\(/i;
 var VARIABLE_NAME_PATTERN = /^--\S+$/;
 
 function isLocal(value){
@@ -384,7 +384,7 @@ function optimizeBody(rule, properties, context) {
     property = _properties[i];
     name = property.name;
 
-    if (!PROPERTY_NAME_PATTERN.test(name)) {
+    if (!PROPERTY_NAME_PATTERN.test(name) && !levelOptions.keepProperties.includes(name)) {
       propertyToken = property.all[property.position];
       context.warnings.push('Invalid property name \'' + name + '\' at ' + formatPosition(propertyToken[1][2][0]) + '. Ignoring.');
       property.unused = true;

--- a/lib/options/optimization-level.js
+++ b/lib/options/optimization-level.js
@@ -13,6 +13,7 @@ var DEFAULTS = {};
 DEFAULTS[OptimizationLevel.Zero] = {};
 DEFAULTS[OptimizationLevel.One] = {
   cleanupCharsets: true,
+  keepProperties: ['cx','cy','r','rx','ry','x','y'],
   normalizeUrls: true,
   optimizeBackground: true,
   optimizeBorderRadius: true,


### PR DESCRIPTION
As referenced in #1021 SVG properties such as `cx`, `cy`, `r`, `rx`,`ry`, `x`, `y` are being removed and in current version there's no sane option to change this behavior other than using ignore comments. My proposal is to allow user to set a list of properties that should be allowed despite not passing `PROPERTY_NAME_PATTERN`.