### PR TITLE
Update README.md - semicolonAfterLastProperty to format

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ new CleanCSS({
       beforeBlockBegins: false, // controls if a space comes before a block begins; e.g. `.block {`; defaults to `false`
       beforeValue: false // controls if a space comes before a value; e.g. `width: 1rem`; defaults to `false`
     },
-    wrapAt: false // controls maximum line length; defaults to `false`
+    wrapAt: false, // controls maximum line length; defaults to `false`
+    semicolonAfterLastProperty: false // controls removing trailing semicolons in rule; defaults to `false` - means remove
   }
 })
 ```
@@ -369,7 +370,6 @@ new CleanCSS({
       tidyAtRules: true, // controls at-rules (e.g. `@charset`, `@import`) optimizing; defaults to `true`
       tidyBlockScopes: true, // controls block scopes (e.g. `@media`) optimizing; defaults to `true`
       tidySelectors: true, // controls selectors optimizing; defaults to `true`,
-      semicolonAfterLastProperty: false, // controls removing trailing semicolons in rule; defaults to `false` - means remove
       transform: function () {} // defines a callback for fine-grained property optimization; defaults to no-op
     }
   }


### PR DESCRIPTION
See #983 and #1023
README.md change only
Moved semicolonAfterLastProperty from level 1 to format.
