### PR TITLE
Update merge-into-shorthands-test.js

### DIFF
--- a/test/optimizer/level-2/properties/merge-into-shorthands-test.js
+++ b/test/optimizer/level-2/properties/merge-into-shorthands-test.js
@@ -15,7 +15,7 @@ function _optimize(source) {
     warnings: []
   });
 
-  var compat = compatibilityFrom(compat);
+  var compat = compatibilityFrom(source);
   var options = {
     compatibility: compat,
     level: {


### PR DESCRIPTION
The wrong variable was used

Not sure how it worked before, noticed it while switching to const/let