### PR TITLE
Fix #1122 - do not wrap data uri with single quote

### DIFF
--- a/lib/reader/rewrite-url.js
+++ b/lib/reader/rewrite-url.js
@@ -1,6 +1,8 @@
 var path = require('path');
 var url = require('url');
 
+var isDataUriResource = require('../utils/is-data-uri-resource');
+
 var DOUBLE_QUOTE = '"';
 var SINGLE_QUOTE = '\'';
 var URL_PREFIX = 'url(';
@@ -24,12 +26,8 @@ function rebase(uri, rebaseConfig) {
     return uri;
   }
 
-  if (isRemote(uri) || isSVGMarker(uri) || isInternal(uri)) {
+  if (isRemote(uri) || isSVGMarker(uri) || isInternal(uri) || isDataUriResource(uri)) {
     return uri;
-  }
-
-  if (isData(uri)) {
-    return '\'' + uri + '\'';
   }
 
   if (isRemote(rebaseConfig.toBase)) {
@@ -55,10 +53,6 @@ function isInternal(uri) {
 
 function isRemote(uri) {
   return /^[^:]+?:\/\//.test(uri) || uri.indexOf('//') === 0;
-}
-
-function isData(uri) {
-  return uri.indexOf('data:') === 0;
 }
 
 function absolute(uri, rebaseConfig) {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1274,6 +1274,14 @@ vows.describe('integration tests')
         '.icon-logo{background-image:url("data:image/x-icon;base64,AAABAAEAEBA")}',
         '.icon-logo{background-image:url(data:image/x-icon;base64,AAABAAEAEBA)}'
       ],
+      'strip quotes from font data URI with mediatype': [
+        '@font-face{src:url("data:application/x-font-woff;base64,d09GRk9UVE8AAENAAA0AAAAA")}',
+        '@font-face{src:url(data:application/x-font-woff;base64,d09GRk9UVE8AAENAAA0AAAAA)}'
+      ],
+      'strip quotes from font data URI without mediatype': [
+        '@font-face{src:url("data:;base64,d09GRk9UVE8AAENAAA0AAAAA")}',
+        '@font-face{src:url(data:;base64,d09GRk9UVE8AAENAAA0AAAAA)}'
+      ],
       'cut off url content on selector level': [
         'a{background:url(image/}',
         ''


### PR DESCRIPTION
Fixes #1122 

I am not sure why single quote explicitly added to data uri. It sounds unreasonable to me.

All old tests have been passed because when mediatype is not omitted, the data uri such as `data:application/x-font-woff;base64,d09GRk9UVE8AAENAAA0AAAAA` will match `isInternal()` check. Nobody actually goes to `isData()` unless the mediatype part was omitted from data uri, such as `data:;base64,d09GRk9UVE8AAENAAA0AAAAA`