### PR TITLE
Add support for removing duplicate declarations of the same variable

### DIFF
--- a/lib/optimizer/level-2/optimize.js
+++ b/lib/optimizer/level-2/optimize.js
@@ -8,6 +8,7 @@ var removeDuplicateMediaQueries = require('./remove-duplicate-media-queries');
 var removeDuplicates = require('./remove-duplicates');
 var removeUnusedAtRules = require('./remove-unused-at-rules');
 var restructure = require('./restructure');
+var simplifyVariables = require('./simplify-variables');
 
 var optimizeProperties = require('./properties/optimize');
 
@@ -103,6 +104,10 @@ function level2Optimize(tokens, context, withRestructuring) {
 
   if (levelOptions.restructureRules && !levelOptions.mergeAdjacentRules && withRestructuring) {
     restructure(tokens, context);
+  }
+
+  if (levelOptions.simplifyVariables) {
+    simplifyVariables(tokens, context);
   }
 
   if (levelOptions.removeDuplicateFontRules) {

--- a/lib/optimizer/level-2/simplify-variables.js
+++ b/lib/optimizer/level-2/simplify-variables.js
@@ -1,0 +1,33 @@
+function simplifyVariables(tokens) {
+    var usedVariables = {};
+
+    for (var i = tokens.length - 1; i >= 0; i--) {
+        if (tokens[i][0] === 'rule') {
+            var stringifiedRule = JSON.stringify(tokens[i][1]);
+
+            for (var j = tokens[i][2].length - 1; j >= 0 ; j--) {
+                var property = tokens[i][2][j];
+
+                if (property[0] === 'property' && property[1][0] === 'property-name') {
+
+                    var propertyName = property[1][1];
+
+                    if (propertyName.substring(0,2) === '--') {
+                        if (usedVariables[stringifiedRule] && usedVariables[stringifiedRule][propertyName]) {
+                            tokens[i][2].splice(j, 1);
+                        } else {
+
+                            if (!usedVariables[stringifiedRule]) {
+                                usedVariables[stringifiedRule] = {};
+                            }
+
+                            usedVariables[stringifiedRule][propertyName] = property;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+module.exports = simplifyVariables;

--- a/lib/options/optimization-level.js
+++ b/lib/options/optimization-level.js
@@ -48,6 +48,7 @@ DEFAULTS[OptimizationLevel.Two] = {
   removeDuplicateRules: true,
   removeUnusedAtRules: false,
   restructureRules: false,
+  simplifyVariables: false,
   skipProperties: []
 };
 

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -2592,8 +2592,32 @@ vows.describe('integration tests')
       'Polymer mixins - inlined variables': [
         '.spinner{-webkit-animation:container-rotate var(--paper-spinner-container-rotation-duration) linear infinite}',
         '.spinner{-webkit-animation:container-rotate var(--paper-spinner-container-rotation-duration) linear infinite}'
-      ]
+      ],
     }, { level: 2 })
+  )
+  .addBatch(
+    optimizerContext('simplify variables', {
+      'keep necessary variables': [
+        'a{--reference: #111; --border: var(--reference)}',
+        'a{--reference:#111;--border:var(--reference)}'
+      ],
+      'remove unnecessary variables': [
+        'a{--border:#000; --reference: #111; --border: var(--reference)}',
+        'a{--reference:#111;--border:var(--reference)}'
+      ],
+      'remove unnecessary variables on separate rules': [
+        'a{--border:#000;--border:#100;} b{--border:#200;--border:#300;}',
+        'a{--border:#100}b{--border:#300}'
+      ],
+      'ignore non variable properties': [
+        'a{background: red}',
+        'a{background:red}'
+      ],
+    }, { level: {
+      2: {
+        simplifyVariables: true,
+      }
+    }})
   )
   .addBatch(
     optimizerContext('beautify formatting', {

--- a/test/options/optimization-level-test.js
+++ b/test/options/optimization-level-test.js
@@ -146,7 +146,8 @@ vows.describe(optimizationLevelFrom)
           removeDuplicateRules: true,
           removeUnusedAtRules: false,
           restructureRules: false,
-          skipProperties: []
+          simplifyVariables: false,
+          skipProperties: [],
         });
       }
     },
@@ -213,6 +214,7 @@ vows.describe(optimizationLevelFrom)
           removeDuplicateRules: true,
           removeUnusedAtRules: false,
           restructureRules: false,
+          simplifyVariables: false,
           skipProperties: []
         });
       }
@@ -345,6 +347,7 @@ vows.describe(optimizationLevelFrom)
           removeDuplicateRules: false,
           removeUnusedAtRules: false,
           restructureRules: false,
+          simplifyVariables: false,
           skipProperties: []
         });
       }
@@ -401,6 +404,7 @@ vows.describe(optimizationLevelFrom)
           removeDuplicateRules: false,
           removeUnusedAtRules: false,
           restructureRules: false,
+          simplifyVariables: false,
           skipProperties: []
         });
       }
@@ -495,6 +499,7 @@ vows.describe(optimizationLevelFrom)
           removeDuplicateRules: true,
           removeUnusedAtRules: false,
           restructureRules: false,
+          simplifyVariables: false,
           skipProperties: []
         });
       }
@@ -551,6 +556,7 @@ vows.describe(optimizationLevelFrom)
           removeDuplicateRules: true,
           removeUnusedAtRules: false,
           restructureRules: false,
+          simplifyVariables: false,
           skipProperties: []
         });
       }
@@ -607,7 +613,8 @@ vows.describe(optimizationLevelFrom)
           removeDuplicateRules: false,
           removeUnusedAtRules: false,
           restructureRules: false,
-          skipProperties: []
+          simplifyVariables: false,
+          skipProperties: [],
         });
       }
     },
@@ -663,6 +670,7 @@ vows.describe(optimizationLevelFrom)
           removeDuplicateRules: false,
           removeUnusedAtRules: false,
           restructureRules: false,
+          simplifyVariables: false,
           skipProperties: []
         });
       }


### PR DESCRIPTION
Behind the level 2 flag `simplifyVariables`

An example is:

```css
.rule {
  --some-variable: red;
  --some-variable: blue;
}
```

Should be reduced to:

```css
.rule {
  --some-variable: blue;
}
```

Also, the variables should not bleed between multiple rules:
```css
.ruleA {
  --some-variable: red;
  --some-variable: blue;
}
.ruleB {
  --some-variable: yellow;
  --some-variable: green;
}
```

should reduce to:

```css
.ruleA {
  --some-variable: blue;
}
.ruleB {
  --some-variable: green;
}
```