### PR TITLE
module-test: fix wrong escape characters

### DIFF
--- a/test/module-test.js
+++ b/test/module-test.js
@@ -1153,10 +1153,10 @@ vows.describe('module tests').addBatch({
             -moz-osx-font-smoothing: grayscale;\
           }\
           .glyphicon-asterisk:before {\
-            content: "\2a";\
+            content: "\\2a";\
           }\
           .glyphicon-plus:before {\
-            content: "\2b";\
+            content: "\\2b";\
           }\
         ';
 


### PR DESCRIPTION
These are prohibited in strict mode hence how I noticed it.

EDIT: later we can switch to template literals and make this snippet cleaner.