### PR TITLE
tokenize: remove redundant `length` calls

### DIFF
--- a/lib/tokenizer/tokenize.js
+++ b/lib/tokenizer/tokenize.js
@@ -154,10 +154,10 @@ function intoTokens(source, externalContext, internalContext, isNested) {
       // comment start within block preceded by some content, e.g. div/*<--
       metadatas.push(metadata);
       buffer.push(character);
-      buffers.push(buffer.slice(0, buffer.length - 2));
+      buffers.push(buffer.slice(0, -2));
       isBufferEmpty = false;
 
-      buffer = buffer.slice(buffer.length - 2);
+      buffer = buffer.slice(-2);
       metadata = [position.line, position.column - 1, position.source];
 
       levels.push(level);


### PR DESCRIPTION
`Array.slice()`'s second parameter can be negative which means an offset from the end

Found in my xo branch, which I plan to streamline and open a PR later.