### PR TITLE
Fixes #1166 - error with trailing comma in property value

### DIFF
--- a/lib/optimizer/configuration/break-up.js
+++ b/lib/optimizer/configuration/break-up.js
@@ -461,7 +461,9 @@ function multiplex(splitWith) {
       var _property = _wrapDefault(property.name, property, configuration);
       _property.value = values.slice(from, to);
 
-      splitComponents.push(splitWith(_property, configuration, validator));
+      if (_property.value.length > 0) {
+        splitComponents.push(splitWith(_property, configuration, validator));
+      }
     }
 
     var components = splitComponents[0];

--- a/test/optimizer/configuration/break-up-test.js
+++ b/test/optimizer/configuration/break-up-test.js
@@ -705,6 +705,22 @@ vows.describe(breakUp)
           assert.deepEqual(components[6].name, 'background-clip');
           assert.deepEqual(components[6].value, [['property-value', 'padding-box']]);
         }
+      },
+      'tailing-comma': {
+        'topic': function () {
+          return _breakUp([
+            [
+              'property',
+              ['property-name', 'background'],
+              ['property-value', '#000'],
+              ['property-value', ',']
+            ]
+          ]);
+        },
+        'has background': function (components) {
+          assert.deepEqual(components[7].name, 'background-color');
+          assert.deepEqual(components[7].value, [['property-value', '#000']]);
+        },
       }
     },
     'border': {


### PR DESCRIPTION
I wasn't too sure if this was the correct place to put the test, but it failed before the code change and passes now.

This will also handle empty blocks in the middle of a property-value:
```css
div {
  background: black, , url("bg.gif"),;
}
```

Happy to move the test if that would be helpful