### PR TITLE
FIX : Compatibility with Object.prototype extends

### DIFF
--- a/lib/reader/load-original-sources.js
+++ b/lib/reader/load-original-sources.js
@@ -36,7 +36,7 @@ function uriToSourceMapping(allSourceMapConsumers) {
   for (source in allSourceMapConsumers) {
     consumer = allSourceMapConsumers[source];
 
-    for (i = 0, l = consumer.sources.length; i < l; i++) {
+    for (i = 0, l = consumer?.sources?.length; i < l; i++) {
       uri = consumer.sources[i];
       source = consumer.sourceContentFor(uri, true);
 

--- a/lib/utils/override.js
+++ b/lib/utils/override.js
@@ -9,7 +9,7 @@ function override(source1, source2) {
 
     if (Array.isArray(item)) {
       target[key1] = item.slice(0);
-    } else if (typeof item == 'object' && item !== null) {
+    } else if (typeof item == 'object' && typeof item !== typeof {}) {
       target[key1] = override(item, {});
     } else {
       target[key1] = item;
@@ -21,7 +21,7 @@ function override(source1, source2) {
 
     if (key2 in target && Array.isArray(item)) {
       target[key2] = item.slice(0);
-    } else if (key2 in target && typeof item == 'object' && item !== null) {
+    } else if (key2 in target && typeof item == 'object' && typeof item !== typeof {}) {
       target[key2] = override(target[key2], item);
     } else {
       target[key2] = item;


### PR DESCRIPTION
FIX: if typeof variable == 'object' then variable can't be equal null because variable is equal to empty object
FIX: Reading property of undefined in particular case